### PR TITLE
feat: add empty state UI to products list

### DIFF
--- a/src/features/catalog/ui/ProductsContainer/ProductsLists.jsx
+++ b/src/features/catalog/ui/ProductsContainer/ProductsLists.jsx
@@ -1,8 +1,22 @@
 import ProductCard from "@/entities/product/ProductCard/ProductCard"
 import React from 'react'
+import { useTranslations } from "next-intl";
+import { PackageX } from "lucide-react";
 
 
 const ProductsLists = ({ data , info }) => {
+  const t = useTranslations("filter");
+  
+  // Empty state
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 text-center">
+        <PackageX className="w-16 h-16 text-muted mb-4" />
+        <p className="text-lg text-text">{t("noResults")}</p>
+      </div>
+    );
+  }
+
   return (
     <div className='grid grid-cols-2 md:grid-cols-4 gap-5 '>
       {data.flatMap((pro) =>


### PR DESCRIPTION
## What was done

Added empty state UI to the ProductsLists component to show a friendly message when no products are found in a category or search result.

## Why it matters

Improves user experience by:
- Showing a clear, friendly message when there are no products
- Including an icon (PackageX) to visually indicate the empty state
- Using existing translation key for consistency

## Limitations

- None. This is a non-breaking, purely additive change.