### PR TITLE
fix: add wishlist integration to search results

### DIFF
--- a/src/app/api/products/search/route.js
+++ b/src/app/api/products/search/route.js
@@ -1,9 +1,14 @@
 import { NextResponse } from 'next/server';
 import prisma from '../../../../../prisma/client';
 import { toSafeJson } from '../../../../../prisma/funcs';
+import { getToken } from "next-auth/jwt";
 
 export async function GET(request) {
   try {
+    // Get authenticated user for wishlist
+    const user = await getToken({ request, secret: process.env.NEXTAUTH_SECRET });
+    const userId = user?.sub;
+
     const { searchParams } = new URL(request.url);
 
     // Search query
@@ -148,12 +153,32 @@ export async function GET(request) {
       },
     });
 
-    return NextResponse.json({
-      data: toSafeJson(sortedProducts),
+    // Add wishlist info if user is authenticated
+    let wishlistInfo = null;
+    let productsWithFav = sortedProducts;
+
+    if (userId) {
+      const wishlist = await prisma.wishlist.findUnique({
+        where: { user_id: userId },
+        include: { wishlist_items: true },
+      });
+
+      const wishlistVariantIds = wishlist?.wishlist_items.map((item) => item.variant_id) || [];
+      
+      productsWithFav = sortedProducts.map((product) => ({
+        ...product,
+        isFavorite: wishlistVariantIds.includes(product.variant_id),
+      }));
+
+      wishlistInfo = { wishlist_id: wishlist?.id };
+    }
+
+    const response = {
+      data: toSafeJson(productsWithFav),
       pagination: {
         page,
         limit,
-        total: minRating ? totalProductsCount : totalProductsCount, // Note: rating filter affects actual count
+        total: minRating ? totalProductsCount : totalProductsCount,
         totalPages: Math.ceil(totalProductsCount / limit),
       },
       search: {
@@ -161,7 +186,14 @@ export async function GET(request) {
         filters: { category, minPrice: minPriceNum, maxPrice: maxPriceNum, minRating },
         sort: { by: sortBy, order: sortOrder },
       },
-    });
+    };
+
+    // Add wishlist info if user is authenticated
+    if (wishlistInfo) {
+      response.otherInfo = wishlistInfo;
+    }
+
+    return NextResponse.json(response);
   } catch (error) {
     console.error('Search API error:', error);
     return NextResponse.json(

--- a/src/shared/ui/search/SearchResultsContainer.jsx
+++ b/src/shared/ui/search/SearchResultsContainer.jsx
@@ -14,6 +14,7 @@ const SearchResultsContainer = ({ query: initialQuery, initialData, locale = "en
   
   const [query, setQuery] = useState(initialQuery || searchParams.get("q") || "");
   const [results, setResults] = useState(initialData?.data || []);
+  const [otherInfo, setOtherInfo] = useState(initialData?.otherInfo || null);
   const [isLoading, setIsLoading] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState(null);
@@ -62,6 +63,7 @@ const SearchResultsContainer = ({ query: initialQuery, initialData, locale = "en
       if (res.ok) {
         setResults(data.data || []);
         setPagination(data.pagination || { page: 1, limit: 20, total: 0, totalPages: 0 });
+        setOtherInfo(data.otherInfo || null);
       } else {
         setError(data.error || "Search failed");
         setResults([]);
@@ -292,7 +294,7 @@ const SearchResultsContainer = ({ query: initialQuery, initialData, locale = "en
               {/* Products Grid */}
               <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-5">
                 {results.map((product) => (
-                  <ProductCard key={product.variant_id} data={product} />
+                  <ProductCard key={product.variant_id} data={product} otherInfo={{ ...otherInfo, isFavorite: product.isFavorite }} />
                 ))}
               </div>
 


### PR DESCRIPTION
## What was done
Fixed the issue where adding products to wishlist doesn't work on the search results page.

## Why it matters
- Users can now add search results to their wishlist
- Consistent behavior with catalog page

## Changes
- Updated search API () to include wishlist info (, ) for authenticated users
- Updated  to pass  with  to 

## Limitations
- Requires user to be logged in to use wishlist functionality