### PR TITLE
feat: add address selection in checkout flow

### DIFF
--- a/documentation/roadmap/README.md
+++ b/documentation/roadmap/README.md
@@ -240,7 +240,7 @@ A full-featured Next.js e-commerce platform with multi-language support (i18n), 
 
 ### ⚡ Improvements
 
-- [ ] Now, when the user makes an order, the form of the user's address is shown to him and he can only add an address or edit the already existing one. I would like there to be an opportunity to select the existing user addresses in the system, if they are there, if not, then this form was shown. 
+- [x] Now, when the user makes an order, the form of the user's address is shown to him and he can only add an address or edit the already existing one. I would like there to be an opportunity to select the existing user addresses in the system, if they are there, if not, then this form was shown. (Implemented in PR #22)
 
 - [ ] adding full skeleton layout for product page
 
@@ -266,5 +266,6 @@ A full-featured Next.js e-commerce platform with multi-language support (i18n), 
 
 ### 1.3.2026
 - Fixed: Search page wishlist functionality - added proper authentication handling, auto-create wishlist for new users, fixed toast message for unauthenticated users
+- Added: Address selection in checkout flow - users can now select existing saved addresses or add new ones during checkout (PR #22)
 
 (repeatable section)

--- a/src/features/add-user-address/ui/addUserAddressModal.jsx
+++ b/src/features/add-user-address/ui/addUserAddressModal.jsx
@@ -2,34 +2,62 @@
 import React, { useEffect, useState } from "react";
 import { set, useForm } from "react-hook-form";
 import Modal from "@/shared/ui/modal/Modal";
-import { addUserAddress  , updateUserAddress} from "../model/UserAddress";
+import { addUserAddress, updateUserAddress } from "../model/UserAddress";
 import toast from "react-hot-toast";
 import Fetch from "@/shared/lib/fetch";
 import Miniloader from "@/shared/ui/Loading/ComponentLoader/miniloader";
 import { useTranslations } from "next-intl";
+import { MapPin, Plus, Check } from "lucide-react";
 
-const AddUserAddressForm = ({ setStep = () => {} , setOrderInfo = () => {}, onAddressAdded, onCancel , addressForEdit = false }) => {
+const AddUserAddressForm = ({ setStep = () => {}, setOrderInfo = () => {}, onAddressAdded, onCancel, addressForEdit = false }) => {
   const t = useTranslations("address");
   const [loading, setLoading] = useState(false);
   const [address, setAddress] = useState(addressForEdit);
+  const [allAddresses, setAllAddresses] = useState([]);
+  const [selectedAddressId, setSelectedAddressId] = useState(null);
+  const [showAddForm, setShowAddForm] = useState(false);
+  
+  // Check if we're in checkout mode
+  const isCheckoutMode = setStep && setOrderInfo;
 
   const {
     register,
     handleSubmit,
     formState: { errors },
     setValue,
-    setError
+    setError,
+    reset
   } = useForm();
 
-  let fillForm = ({ street , city , isDefault , zip , country , phone , state }) => {
-      setValue("street", street);
-      setValue("city",  city);
-      setValue("state",  state);
-      setValue("zip", zip);
-      setValue("country", country);
-      setValue("phone", phone);
-      setValue("isDefault", isDefault);
-  }
+  let fillForm = ({ street, city, isDefault, zip, country, phone, state }) => {
+    setValue("street", street);
+    setValue("city", city);
+    setValue("state", state);
+    setValue("zip", zip);
+    setValue("country", country);
+    setValue("phone", phone);
+    setValue("isDefault", isDefault);
+  };
+
+  // Fetch all addresses
+  let getAllAddresses = async () => {
+    try {
+      setLoading(true);
+      const response = await Fetch("/api/user/addresses", "GET");
+      if (response?.data?.addresses) {
+        setAllAddresses(response.data.addresses);
+        // Auto-select default address if in checkout mode
+        const defaultAddr = response.data.addresses.find((addr) => addr.isDefault === true);
+        if (defaultAddr) {
+          setSelectedAddressId(defaultAddr.id);
+        }
+      }
+    } catch (error) {
+      console.error("Error fetching addresses:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   let getDefaultAddress = async () => {
     try {
@@ -39,7 +67,7 @@ const AddUserAddressForm = ({ setStep = () => {} , setOrderInfo = () => {}, onAd
       );
 
       if (defaultAddress) {
-        fillForm(defaultAddress)
+        fillForm(defaultAddress);
         setAddress(defaultAddress);
       }
     } catch (error) {
@@ -48,20 +76,45 @@ const AddUserAddressForm = ({ setStep = () => {} , setOrderInfo = () => {}, onAd
       setLoading(false);
     }
   };
+
   useEffect(() => {
-    if (!address) {
+    if (isCheckoutMode) {
+      // In checkout mode, fetch all addresses
+      getAllAddresses();
+    } else if (!address) {
       getDefaultAddress();
     }
     if (addressForEdit) {
-      fillForm(addressForEdit)
+      fillForm(addressForEdit);
     }
-  }, [address , addressForEdit]);
+  }, [address, addressForEdit, isCheckoutMode]);
+
+  // Handle selecting an existing address
+  const handleSelectAddress = (addr) => {
+    setSelectedAddressId(addr.id);
+    fillForm(addr);
+    setShowAddForm(false);
+  };
+
+  // Handle continue with selected address in checkout mode
+  const handleContinueWithSelected = () => {
+    if (selectedAddressId) {
+      const selectedAddr = allAddresses.find((addr) => addr.id === selectedAddressId);
+      if (selectedAddr) {
+        setOrderInfo((s) => ({ ...s, address: selectedAddr }));
+        setStep(2);
+        return;
+      }
+    }
+    // If no address selected, show form
+    setShowAddForm(true);
+  };
 
   const onSubmit = async (data) => {
     setLoading(true);
     try {
       if (address && address.street === data.street && address.city === data.city && address.state === data.state && address.zip === data.zip) {
-        if ( setStep && setOrderInfo) {
+        if (setStep && setOrderInfo) {
           // If we are in the checkout flow, we just set the order info and move to the next step
           setOrderInfo((s) => ({ ...s, address: data }));
           setStep(2);
@@ -69,10 +122,10 @@ const AddUserAddressForm = ({ setStep = () => {} , setOrderInfo = () => {}, onAd
         toast.success(t("errors.allreadyAdded"));
         onAddressAdded && onAddressAdded();
       } else {
-        const res = await addUserAddress({ ...data , id: crypto.randomUUID()});
+        const res = await addUserAddress({ ...data, id: crypto.randomUUID() });
 
         if (res?.status === 409) {
-          setError("isDefault", { type: "server" ,message: t("errors.isDefault") } , { shouldFocus: true }); 
+          setError("isDefault", { type: "server", message: t("errors.isDefault") }, { shouldFocus: true });
           return;
         }
 
@@ -81,14 +134,14 @@ const AddUserAddressForm = ({ setStep = () => {} , setOrderInfo = () => {}, onAd
           setOrderInfo((s) => ({ ...s, address: data }));
           setStep(2);
         }
-        
+
         if (res?.status === 200 || res?.status === 201) {
           toast.success(t("success"));
           if (onAddressAdded) {
             onAddressAdded();
           }
         }
-      } 
+      }
     } catch (error) {
       toast.error(t("errors.somethingWentWrong"));
     } finally {
@@ -99,7 +152,7 @@ const AddUserAddressForm = ({ setStep = () => {} , setOrderInfo = () => {}, onAd
   const onUpdate = async (data) => {
     setLoading(true);
     try {
-      const res = await updateUserAddress(addressForEdit.id , data);
+      const res = await updateUserAddress(addressForEdit.id, data);
       if (res?.status === 200 || res?.status === 201) {
         toast.success(t("updated"));
         if (onAddressAdded) {
@@ -111,7 +164,7 @@ const AddUserAddressForm = ({ setStep = () => {} , setOrderInfo = () => {}, onAd
     } finally {
       setLoading(false);
     }
-  } 
+  };
 
   let correctAction = (data) => {
     if (addressForEdit) {
@@ -119,8 +172,266 @@ const AddUserAddressForm = ({ setStep = () => {} , setOrderInfo = () => {}, onAd
     } else {
       onSubmit(data);
     }
+  };
+
+  // In checkout mode: show address selection or add form
+  if (isCheckoutMode && !showAddForm && !addressForEdit) {
+    return (
+      <div className="flex relative flex-col gap-6">
+        {loading && (
+          <div className="flex justify-center absolute top-0 left-0 w-full h-full z-10 bg-surface/80">
+            <Miniloader />
+          </div>
+        )}
+        
+        <div className="flex flex-col gap-2 text-center">
+          <h2 className="text-2xl font-bold text-text">
+            {t("selectAddress") || "Select Shipping Address"}
+          </h2>
+          <p className="text-unactive-text text-sm">
+            {t("selectAddressDescription") || "Choose an existing address or add a new one"}
+          </p>
+        </div>
+
+        {/* Existing Addresses List */}
+        {allAddresses.length > 0 ? (
+          <div className="flex flex-col gap-3">
+            <p className="text-text text-sm font-medium">{t("yourAddresses") || "Your Addresses"}</p>
+            {allAddresses.map((addr) => (
+              <div
+                key={addr.id}
+                onClick={() => handleSelectAddress(addr)}
+                className={`
+                  cursor-pointer p-4 rounded-xl border-2 transition-all
+                  ${selectedAddressId === addr.id 
+                    ? "border-primary bg-primary/10" 
+                    : "border-border hover:border-primary/50"}
+                `}
+              >
+                <div className="flex items-start gap-3">
+                  <div className={`
+                    w-5 h-5 rounded-full border-2 flex items-center justify-center mt-0.5
+                    ${selectedAddressId === addr.id ? "border-primary" : "border-border"}
+                  `}>
+                    {selectedAddressId === addr.id && <div className="w-2.5 h-2.5 rounded-full bg-primary" />}
+                  </div>
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2">
+                      <MapPin className="w-4 h-4 text-primary" />
+                      <span className="text-text font-medium">
+                        {addr.street}, {addr.city}
+                      </span>
+                      {addr.isDefault && (
+                        <span className="text-xs bg-primary/20 text-primary px-2 py-0.5 rounded-full">
+                          {t("default") || "Default"}
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-unactive-text text-sm mt-1">
+                      {addr.state}, {addr.zip}, {addr.country}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-unactive-text text-center py-4">
+            {t("noAddresses") || "No saved addresses"}
+          </p>
+        )}
+
+        {/* Add New Address Option */}
+        <div 
+          onClick={() => setShowAddForm(true)}
+          className="cursor-pointer p-4 rounded-xl border-2 border-dashed border-border hover:border-primary/50 transition flex items-center justify-center gap-2"
+        >
+          <Plus className="w-5 h-5 text-primary" />
+          <span className="text-text font-medium">{t("addNewAddress") || "Add New Address"}</span>
+        </div>
+
+        {/* Continue Button */}
+        <div className="flex gap-3 pt-2">
+          {onCancel && (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="flex-1 p-3 rounded-xl text-center text-text border border-border hover:bg-surface transition"
+            >
+              {t("cancel")}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={handleContinueWithSelected}
+            disabled={!selectedAddressId && allAddresses.length > 0}
+            className={`
+              flex-1 p-3 rounded-xl text-center font-medium transition
+              ${selectedAddressId || allAddresses.length === 0
+                ? "bg-primary text-primary-text hover:opacity-80" 
+                : "bg-muted text-unactive-text cursor-not-allowed"}
+            `}
+          >
+            {selectedAddressId ? (t("continue") || "Continue") : (t("selectAddress") || "Select an Address")}
+          </button>
+        </div>
+      </div>
+    );
   }
 
+  // Show add form when in checkout mode and user clicked "Add New Address"
+  if (isCheckoutMode && showAddForm && !addressForEdit) {
+    return (
+      <form onSubmit={handleSubmit(correctAction)} className="flex relative flex-col gap-6">
+        {loading && (
+          <div className="flex justify-center absolute top-0 left-0 w-full h-full z-10 bg-surface/80">
+            <Miniloader />
+          </div>
+        )}
+        
+        <div className="flex flex-col gap-2 text-center">
+          <h2 className="text-2xl font-bold text-text">{t("add")}</h2>
+          <p className="text-unactive-text text-sm">{t("addDescription")}</p>
+        </div>
+
+        {/* Back to address selection */}
+        {allAddresses.length > 0 && (
+          <button
+            type="button"
+            onClick={() => {
+              setShowAddForm(false);
+              reset();
+            }}
+            className="text-primary text-sm hover:underline flex items-center gap-1"
+          >
+            ← {t("backToAddresses") || "Back to saved addresses"}
+          </button>
+        )}
+
+        <div className="flex flex-col gap-4">
+          <label className="flex flex-col gap-2">
+            <span className="text-text text-sm font-medium">{t("street")}</span>
+            <input
+              {...register("street", {
+                required: t("errors.streetRequired"),
+              })}
+              className="inputStyle"
+              placeholder="123 Main Street"
+              type="text"
+            />
+            {errors.street && (
+              <span className="text-danger text-sm">
+                {errors.street.message}
+              </span>
+            )}
+          </label>
+
+          <div className="grid grid-cols-2 gap-4">
+            <label className="flex flex-col gap-2">
+              <span className="text-text text-sm font-medium">{t("city")}</span>
+              <input
+                {...register("city", { required: t("errors.cityRequired") })}
+                className="inputStyle"
+                placeholder="New York"
+                type="text"
+              />
+              {errors.city && (
+                <span className="text-danger text-sm">
+                  {errors.city.message}
+                </span>
+              )}
+            </label>
+
+            <label className="flex flex-col gap-2">
+              <span className="text-text text-sm font-medium">{t("state")}</span>
+              <input
+                {...register("state", { required: t("errors.stateRequired") })}
+                className="inputStyle"
+                placeholder="NY"
+                type="text"
+              />
+              {errors.state && (
+                <span className="text-danger text-sm">
+                  {errors.state.message}
+                </span>
+              )}
+            </label>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <label className="flex flex-col gap-2">
+              <span className="text-text text-sm font-medium">{t("zip")}</span>
+              <input
+                {...register("zip", { required: t("errors.zipRequired") })}
+                className="inputStyle"
+                placeholder="10001"
+                type="text"
+              />
+              {errors.zip && (
+                <span className="text-danger text-sm">{errors.zip.message}</span>
+              )}
+            </label>
+
+            <label className="flex flex-col gap-2">
+              <span className="text-text text-sm font-medium">{t("country")}</span>
+              <input
+                {...register("country", { required: t("errors.countryRequired") })}
+                className="inputStyle"
+                placeholder="United States"
+                type="text"
+              />
+              {errors.country && (
+                <span className="text-danger text-sm">
+                  {errors.country.message}
+                </span>
+              )}
+            </label>
+          </div>
+
+          <label className="flex flex-col gap-2">
+            <span className="text-text text-sm font-medium">{t("phone")}</span>
+            <input
+              {...register("phone", { required: t("errors.phoneRequired") })}
+              className="inputStyle"
+              placeholder="+1 (555) 123-4567"
+              type="tel"
+            />
+            {errors.phone && (
+              <span className="text-danger text-sm">{errors.phone.message}</span>
+            )}
+          </label>
+
+          <label className="flex items-center gap-2">
+            <input
+              {...register("isDefault")}
+              type="checkbox"
+              className="w-4 h-4 rounded border-border text-primary focus:ring-primary"
+            />
+            <span className="text-text text-sm">{t("setDefault")}</span>
+          </label>
+          <span>{errors.isDefault && <span className="text-danger text-center text-sm">{errors.isDefault.message}</span>}</span>
+        </div>
+
+        <div className="flex gap-3 pt-2">
+          <button
+            type="button"
+            onClick={() => setShowAddForm(false)}
+            className="flex-1 p-3 rounded-xl text-center text-text border border-border hover:bg-surface transition"
+          >
+            {t("back") || "Back"}
+          </button>
+          <button
+            type="submit"
+            className="flex-1 p-3 rounded-xl text-center text-primary-text bg-primary hover:opacity-80 transition"
+          >
+            {t("add")}
+          </button>
+        </div>
+      </form>
+    );
+  }
+
+  // Original form for non-checkout mode (profile editing, etc.)
   return (
     <form onSubmit={handleSubmit(correctAction)} className="flex relative flex-col gap-6">
       {loading && <div className="flex justify-center absolute top-0 left-0 w-full h-full"><Miniloader /></div>}


### PR DESCRIPTION

## What was done
Added the ability for users to select existing saved addresses during checkout, instead of always showing the address form.

## Why it matters
Improves user experience by:
- Allowing quick selection of previously saved addresses
- Auto-selecting the default address if one exists
- Still providing the option to add new addresses during checkout

## Changes
- Modified `AddUserAddressForm` component to detect checkout mode
- Added address selection UI with list of existing addresses
- Added option to add new address from checkout flow
- Maintained backward compatibility with profile address management

## Limitations
- Requires user to be logged in (already required for checkout)
- No address deletion from checkout flow (can be added later)
