### PR TITLE
Fix: Auth fixes for orders API and forms (#26, #30)

### DIFF
--- a/src/app/api/orders/route.js
+++ b/src/app/api/orders/route.js
@@ -6,6 +6,10 @@ import { getToken } from "next-auth/jwt";
 export let GET = async (req) => {
     const user = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });  
 
+    if (!user) {
+        return new NextResponse(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+    }
+
     const orders = await prisma.orders.findMany({
         where: {
             user_id: user.id

--- a/src/features/auth/ui/forms/LoginForm.jsx
+++ b/src/features/auth/ui/forms/LoginForm.jsx
@@ -4,6 +4,7 @@ import { useForm } from "react-hook-form";
 import { signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import toast from "react-hot-toast";
 
 const LoginForm = () => {
   const t = useTranslations("auth.login");
@@ -26,6 +27,7 @@ const LoginForm = () => {
 
     if (res?.status === 401) {
        setError("root" , { message: t("errors.invalid") })
+       toast.error(t("errors.invalid"));
      }
 
     if (!res?.error) {

--- a/src/features/auth/ui/forms/RegisterForm.jsx
+++ b/src/features/auth/ui/forms/RegisterForm.jsx
@@ -5,6 +5,7 @@ import { register as registerUser } from "@/features/auth/model/register";
 import { signIn } from "next-auth/react";
 import { useRouter} from "next/navigation";
 import { useTranslations } from "next-intl";
+import toast from "react-hot-toast";
 
 const RegisterForm = () => {
   const t = useTranslations("auth.register");
@@ -32,14 +33,16 @@ const RegisterForm = () => {
         });
 
         if (res?.error) {
-          console.error("Ошибка логина:", res.error);
+          console.error("Login error:", res.error);
+          toast.error(t("errors.somethingWrong"));
         } else {
           reset();
           router.replace("/");
         }
       }
     } catch (error) {
-      console.error("Ошибка регистрации:", error);
+      console.error("Registration error:", error);
+      toast.error(t("errors.somethingWrong"));
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## ✅ What was done

- **Issue #26**: Added authentication check to  route - returns 401 Unauthorized for unauthenticated users instead of crashing
- **Issue #30**: Added toast notifications to LoginForm and RegisterForm for error feedback using react-hot-toast

## 🧠 Why it matters

- Prevents runtime crashes when unauthenticated users access the orders API
- Improves user experience by showing clear error messages instead of silent failures

## 🔗 Related Issues

- Closes #26
- Closes #30

## ⚠️ Notes

- Uses existing react-hot-toast library already in use by the project
- Follows same authentication pattern as cart and wishlist API routes