### PR TITLE
Fix: Auth improvements - issues #26 and #30

### DIFF
--- a/src/app/api/orders/route.js
+++ b/src/app/api/orders/route.js
@@ -5,6 +5,7 @@ import { getToken } from "next-auth/jwt";
 
 export let GET = async (req) => {
     const user = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });  
+    if (!user) return new Response("Unauthorized", { status: 401 });
 
     const orders = await prisma.orders.findMany({
         where: {

--- a/src/features/auth/ui/forms/LoginForm.jsx
+++ b/src/features/auth/ui/forms/LoginForm.jsx
@@ -4,6 +4,7 @@ import { useForm } from "react-hook-form";
 import { signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import toast from "react-hot-toast";
 
 const LoginForm = () => {
   const t = useTranslations("auth.login");
@@ -26,10 +27,12 @@ const LoginForm = () => {
 
     if (res?.status === 401) {
        setError("root" , { message: t("errors.invalid") })
+       toast.error(t("errors.invalid"));
      }
 
     if (!res?.error) {
       reset();
+      toast.success(tCommon("success"));
       router.replace("/");
     }
     

--- a/src/features/auth/ui/forms/RegisterForm.jsx
+++ b/src/features/auth/ui/forms/RegisterForm.jsx
@@ -5,6 +5,7 @@ import { register as registerUser } from "@/features/auth/model/register";
 import { signIn } from "next-auth/react";
 import { useRouter} from "next/navigation";
 import { useTranslations } from "next-intl";
+import toast from "react-hot-toast";
 
 const RegisterForm = () => {
   const t = useTranslations("auth.register");
@@ -33,13 +34,16 @@ const RegisterForm = () => {
 
         if (res?.error) {
           console.error("Ошибка логина:", res.error);
+          toast.error(t("errors.somethingWrong"));
         } else {
           reset();
+          toast.success(t("success"));
           router.replace("/");
         }
       }
     } catch (error) {
       console.error("Ошибка регистрации:", error);
+      toast.error(t("errors.somethingWrong"));
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION

## ✅ What was done
- **Issue #26**: Added authentication check to `/api/orders` route to prevent crashes for unauthenticated users (returns 401 Unauthorized)
- **Issue #30**: Added toast notifications to LoginForm and RegisterForm for success/error feedback

## 🧠 Why it matters
- Prevents runtime crashes when unauthenticated users access the orders API
- Improves UX by showing clear feedback to users on auth success/failure

## 🔗 Related Issues
- Closes #26
- Closes #30

## ⚠️ Notes
- Follows existing pattern from `/api/cart/route.js` for auth checks
- Uses existing `react-hot-toast` pattern used elsewhere in the codebase
