### PR TITLE
Fix: Cart quantity limits (#43)

### DIFF
--- a/src/features/add-to-cart/model/handleCartQuantityChangeOnClient.js
+++ b/src/features/add-to-cart/model/handleCartQuantityChangeOnClient.js
@@ -1,12 +1,23 @@
 import { addToCart } from './addToCart.js'
 import { toast } from 'react-hot-toast'
 
+const MAX_QUANTITY = 99;
+const MIN_QUANTITY = 1;
+
 export async function handleCartQuantityChange({ setLoading = () => {} , setCounter = () => {} , setAdded = () => {}, cart_id , variantId , method }){
     
+    // Get current quantity from counter element if available
+    const currentQty = setCounter ? 0 : 0; // We'll track through the callback
 
     if (method === "add") {
       setLoading(true);
-      setCounter((s) => s + 1);
+      setCounter((s) => {
+        if (s >= MAX_QUANTITY) {
+          toast.error(`Maximum quantity is ${MAX_QUANTITY}`);
+          return s;
+        }
+        return s + 1;
+      });
       try {
         let res = await addToCart(variantId, method, cart_id);
 
@@ -24,7 +35,12 @@ export async function handleCartQuantityChange({ setLoading = () => {} , setCoun
 
     if (method === "remove") {
       setLoading(true);
-      setCounter((s) => s - 1);
+      setCounter((s) => {
+        if (s <= MIN_QUANTITY) {
+          return s;
+        }
+        return s - 1;
+      });
       try {
         let res = await addToCart(variantId, method, cart_id);
 

--- a/src/features/add-to-cart/ui/counter.jsx
+++ b/src/features/add-to-cart/ui/counter.jsx
@@ -3,10 +3,19 @@ import { PlusSquare, MinusSquare } from "lucide-react";
 import deleteButton from "./deleteButton";
 
 const Counter = ({ handleClick, state , className }) => {
+  const minQuantity = 1;
+  const maxQuantity = 99;
+  const isAtMin = state?.quantity <= minQuantity;
+  const isAtMax = state?.quantity >= maxQuantity;
+
   return (
     <div className={`flex justify-between w-full gap-5 ${className}`}>
       <div className="flex justify-between w-full gap-1.5 ">
-        <button disabled={state?.loading} onClick={() => handleClick("remove")}>
+        <button 
+          disabled={state?.loading || isAtMin} 
+          onClick={() => handleClick("remove")}
+          className={isAtMin ? "opacity-30" : ""}
+        >
           <MinusSquare className={`${state?.loading ? "opacity-50" : null} text-text`} />
         </button>
 
@@ -14,7 +23,11 @@ const Counter = ({ handleClick, state , className }) => {
           {state?.quantity}
         </div>
 
-        <button disabled={state?.loading} onClick={() => handleClick("add")}>
+        <button 
+          disabled={state?.loading || isAtMax} 
+          onClick={() => handleClick("add")}
+          className={isAtMax ? "opacity-30" : ""}
+        >
           <PlusSquare className={`${state?.loading ? "opacity-50" : null} text-text`} />
         </button>
       </div>


### PR DESCRIPTION
## ✅ What was done
- Added minimum (1) and maximum (99) quantity limits to the cart counter
- Disabled minus button when quantity is at minimum (1)
- Disabled plus button when quantity is at maximum (99)
- Added validation in cart quantity change handler to prevent exceeding limits
- Added toast notification when trying to exceed maximum quantity

## 🧠 Why it matters
- Prevents users from adding unrealistic quantities to cart
- Improves user experience with clear visual feedback
- Prevents potential API issues with extreme quantities

## 🔗 Related Issues
- Closes #43

## ⚠️ Notes
- Default max quantity set to 99 per item
- Default min quantity is 1 (cannot reduce further, must delete)