### PR TITLE
fix: prevent negative total in cart order summary

### DIFF
--- a/documentation/roadmap/README.md
+++ b/documentation/roadmap/README.md
@@ -274,4 +274,7 @@ A full-featured Next.js e-commerce platform with multi-language support (i18n), 
 ### 5.3.2026
 - Fixed: Search API average rating - enabled reviews in query, added avg_rating and review_count to search results, enabled minRating filter (PR #35)
 
+### 7.3.2026
+- Fixed: Cart discount calculation bug - prevented negative total when discount exceeds cart total, removed empty try-catch block in OrderSummary (PR #49)
+
 (repeatable section)

--- a/src/entities/cart/ui/OrderSummary.jsx
+++ b/src/entities/cart/ui/OrderSummary.jsx
@@ -19,20 +19,17 @@ const OrderSummary = ({ total , setCheckout ,  checkout , items }) => {
 
   const [orderModal , setOrderModal] = useState(false)
 
+  const finalTotal = Math.max(0, total - discountAmount);
+
   let discardChecout = () => {
     setCheckout(false)
     setCoupon(false)
     setDiscountAmount(0)
   }
 
-  let handleOrderSummary = () => {
-    setOrderModal(true)
-    try {
-      
-    } catch (error) {
-      return new Error(error)
-    }
-  }
+  const handleOrderSummary = () => {
+    setOrderModal(true);
+  };
 
   return (
     <div className="md:pt-25 p-4 transition-all duration-500 ease-in-out">
@@ -58,7 +55,7 @@ const OrderSummary = ({ total , setCheckout ,  checkout , items }) => {
           )}
           <div className="font-bold flex justify-between">
             <h2>{t("total")}: </h2>
-            <h2>{(total - discountAmount).toFixed(2)}$</h2>
+            <h2>{finalTotal.toFixed(2)}$</h2>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

Fixed a bug in the cart order summary where a discount code could make the total negative.

## Changes

1. **Prevent negative total**: Added  to ensure the final total never goes below zero, even if the discount exceeds the cart total.

2. **Clean up empty try-catch**: Removed an empty try-catch block in the  function that was unnecessary and could mask errors.

3. **Improved code clarity**: Extracted the final total calculation into a named constant  for better readability.

## Why it matters

- Prevents incorrect order totals when users apply large discount codes
- Improves code quality by removing dead code
- Makes the calculation logic more transparent

## Testing

Build passes successfully.