### PR TITLE
feat: add theme and language switchers to auth page

### DIFF
--- a/documentation/roadmap/README.md
+++ b/documentation/roadmap/README.md
@@ -236,7 +236,7 @@ A full-featured Next.js e-commerce platform with multi-language support (i18n), 
 - [ ] Theme switcher:
   - Description: A beautiful component for switching themes.
   - Priority: Medium
-  - Notes: To implement this component, you first need to change the user's portal because only the user who is already registered has access to the portal now, and the users who are not registered, they go to the login page, and it is necessary that there is a button for moving to the registration page, and at the bottom there were those very components for changing the language and changing the theme.
+  - Notes: To implement this component, you first need to change the user's portal because only the user who is already registered has access to the portal now, and the users who are not registered, they go to the login page, and it is necessary that there is a button for moving to the registration page, and at the bottom there were those very components for changing the language and changing the theme. (Partially implemented in PR #56 - added to auth page)
 
 ### ⚡ Improvements
 
@@ -278,5 +278,8 @@ A full-featured Next.js e-commerce platform with multi-language support (i18n), 
 
 ### 5.3.2026
 - Fixed: Search API average rating - enabled reviews in query, added avg_rating and review_count to search results, enabled minRating filter (PR #35)
+
+### 7.3.2026
+- Added: Theme and language switchers to auth page - unauthenticated users can now switch themes (light, dark, vintage, retro) and languages (en, ru, fa) before logging in (PR #56)
 
 (repeatable section)

--- a/src/features/auth/ui/AuthFormLayout.jsx
+++ b/src/features/auth/ui/AuthFormLayout.jsx
@@ -4,6 +4,8 @@ import LoginForm from "./forms/LoginForm";
 import RegisterForm from "./forms/RegisterForm";
 import OAuthForm from "./OAuthForm/OAuthForm";
 import { useTranslations } from "next-intl";
+import ThemeSwitcher from "@/widgets/header/ui/ThemeSwitcher";
+import LangSwitcher from "@/shared/i18n/ui/Switcher";
 
 const AuthFormLayout = () => {
   const t = useTranslations("auth");
@@ -38,6 +40,12 @@ const AuthFormLayout = () => {
           >
             {form === "login" ? tLogin("register") : tRegister("login")}
           </button>
+        </div>
+        
+        {/* Theme and Language Switchers for unauthenticated users */}
+        <div className="flex items-center gap-4 mt-4 pt-4 border-t border-border">
+          <ThemeSwitcher />
+          <LangSwitcher />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Added ThemeSwitcher and LangSwitcher components to the authentication page, allowing unauthenticated users to:
- Switch between 4 themes (light, dark, vintage, retro)
- Switch between 3 languages (English, Russian, Persian)

## Changes

- Modified  to import and display ThemeSwitcher and LangSwitcher components
- Added a styled container at the bottom of the auth form with both switchers

## Why It Matters

Previously, only logged-in users could access theme and language switching via the header. Unauthenticated users visiting the auth page had no way to:
- Preview different themes before logging in
- Switch to their preferred language before registering

This improves UX for new visitors who want to explore the site in their preferred language/theme before creating an account.

## Limitations

- Theme preference is stored in localStorage (same as logged-in users)
- Language switcher works the same way as in the header