### PR TITLE
Fix: Add null checks for product, wishlist, and addresses APIs (#52 #53 #54)

### DIFF
--- a/src/app/api/products/route.js
+++ b/src/app/api/products/route.js
@@ -51,7 +51,7 @@ export async function GET(req) {
 
       return NextResponse.json({
         data: toSafeJson(productsWithFav),
-        otherInfo: { wishlist_id: wishlist.id },
+        otherInfo: { wishlist_id: wishlist?.id },
       });
     }
 

--- a/src/app/api/user/addresses/route.js
+++ b/src/app/api/user/addresses/route.js
@@ -89,7 +89,7 @@ export const DELETE = async (req) => {
     })
     
     const addresses = existingAddresses?.addresses ?? [];
-    const addressToDelete = existingAddresses.addresses.find((address) => address.id === addressId);
+    const addressToDelete = addresses.find((address) => address.id === addressId);
 
     if (addressToDelete) {
         await prisma.user.update({
@@ -127,7 +127,7 @@ export const PUT = async (req) => {
     })
 
     const addresses = existingAddresses?.addresses ?? [];
-    const addressToUpdate = existingAddresses.addresses.find((address) => address.id === body.id);
+    const addressToUpdate = addresses.find((address) => address.id === body.id);
 
     if (addressToUpdate) {
         const response = await prisma.user.update({

--- a/src/entities/product/ui/MainInfo.jsx
+++ b/src/entities/product/ui/MainInfo.jsx
@@ -169,13 +169,13 @@ const  MainInfo = ({ product , otherInfo }) => {
 
       {/* Product Description */}
       <div>
-        <p className="text-xl text-text">{product.products.description}</p>
+        <p className="text-xl text-text">{product?.products?.description}</p>
       </div>
 
       {/* add to favorite , cart button */}
       <div className="grid grid-cols-2 gap-4 mt-6">
         <div className={`border-2 border-border rounded flex center hover:border-danger transition ${otherInfo?.isFavorite ? "border-danger" : null}`}>
-          <AddToWishListCom wishlistInfo={otherInfo} variantId={currentVariant.id} productId={product.products.id}> 
+          <AddToWishListCom wishlistInfo={otherInfo} variantId={currentVariant?.id} productId={product?.products?.id}> 
           {otherInfo?.isFavorite ? t("addedToWishlist") : t("addToWishlist")}
         </AddToWishListCom>
         </div>


### PR DESCRIPTION
## ✅ What was done
- Added optional chaining for `product?.products?.description` and `product?.products?.id` in MainInfo.jsx to prevent runtime crashes
- Added null check for `wishlist?.id` in products API route
- Fixed null checks in user addresses API route for both DELETE and PUT handlers using existing `addresses` variable

## 🧠 Why it matters
These null checks prevent runtime crashes when product data is incomplete, users have no wishlist, or user addresses are missing. This improves stability and prevents 500 errors.

## 🔗 Related Issues
- Closes #52
- Closes #53  
- Closes #54

## ⚠️ Notes
- All changes are minimal, isolated fixes
- Build passes successfully
- No breaking changes introduced