### PR TITLE
feat: add loading skeletons for catalog, search, and wishlist pages

### DIFF
--- a/documentation/roadmap/README.md
+++ b/documentation/roadmap/README.md
@@ -276,6 +276,9 @@ A full-featured Next.js e-commerce platform with multi-language support (i18n), 
 ### 7.3.2026
 - Fixed: Multiple bugs in cart checkout flow - removed empty try-catch blocks, fixed typo in function name, added null check for product images, simplified redundant logic in wishlist component (PR #51)
 
+### 8.3.2026
+- Added: Loading skeletons for catalog, search, and wishlist pages - created loading.jsx files with animated skeleton UI components for better UX while pages load (PR #66)
+
 ### 5.3.2026
 - Fixed: Search API average rating - enabled reviews in query, added avg_rating and review_count to search results, enabled minRating filter (PR #35)
 

--- a/src/app/[locale]/catalog/loading.jsx
+++ b/src/app/[locale]/catalog/loading.jsx
@@ -1,0 +1,38 @@
+"use client";
+
+import React from "react";
+
+// Reusable skeleton component
+const SkeletonCard = () => (
+  <div className="animate-pulse bg-surface border border-border rounded-xl p-4 flex flex-col items-center">
+    <div className="w-full h-32 bg-border rounded-lg mb-4" />
+    <div className="h-5 bg-border rounded w-3/4 mb-2" />
+    <div className="h-4 bg-border rounded w-1/2" />
+  </div>
+);
+
+// Category card skeleton for catalog page
+const CategoryCardSkeleton = () => (
+  <div className="animate-pulse bg-surface border border-border rounded-xl p-6 flex flex-col items-center justify-center min-h-[200px]">
+    <div className="w-20 h-20 bg-border rounded-full mb-4" />
+    <div className="h-6 bg-border rounded w-24 mb-2" />
+    <div className="h-4 bg-border rounded w-16" />
+  </div>
+);
+
+const CatalogLoadingSkeleton = () => {
+  return (
+    <main 
+      className="h-full grid grid-cols-2 md:grid-cols-5 gap-10 p-5 md:p-20"
+      role="status"
+      aria-label="Loading categories"
+    >
+      {/* Show 10 skeleton cards to match the 10 categories */}
+      {Array.from({ length: 10 }).map((_, i) => (
+        <CategoryCardSkeleton key={i} />
+      ))}
+    </main>
+  );
+};
+
+export default CatalogLoadingSkeleton;

--- a/src/app/[locale]/search/loading.jsx
+++ b/src/app/[locale]/search/loading.jsx
@@ -1,0 +1,46 @@
+"use client";
+
+import React from "react";
+import ProductCardSkeleton from "@/shared/ui/skeleton/ui/ProductCardSkeleton";
+
+// Reusable skeleton line component
+const SkeletonLine = ({ className = "" }) => (
+  <div className={`bg-surface animate-pulse rounded ${className}`} />
+);
+
+// Search page header skeleton
+const SearchHeaderSkeleton = () => (
+  <div className="p-5 md:p-10">
+    <div className="flex items-center gap-4 mb-6">
+      <SkeletonLine className="h-8 w-48" />
+      <SkeletonLine className="h-6 w-24" />
+    </div>
+    <SkeletonLine className="h-5 w-80" />
+  </div>
+);
+
+// Product grid skeleton for search results
+const SearchResultsSkeleton = ({ productCount = 8 }) => {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-5 p-5 md:p-10 pt-0">
+      {Array.from({ length: productCount }).map((_, i) => (
+        <ProductCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+};
+
+const SearchLoadingSkeleton = () => {
+  return (
+    <main 
+      className="min-h-screen"
+      role="status"
+      aria-label="Loading search results"
+    >
+      <SearchHeaderSkeleton />
+      <SearchResultsSkeleton />
+    </main>
+  );
+};
+
+export default SearchLoadingSkeleton;

--- a/src/app/[locale]/wishlist/loading.jsx
+++ b/src/app/[locale]/wishlist/loading.jsx
@@ -1,0 +1,42 @@
+"use client";
+
+import React from "react";
+import ProductCardSkeleton from "@/shared/ui/skeleton/ui/ProductCardSkeleton";
+
+// Reusable skeleton line component
+const SkeletonLine = ({ className = "" }) => (
+  <div className={`bg-surface animate-pulse rounded ${className}`} />
+);
+
+// Wishlist page header skeleton
+const WishlistHeaderSkeleton = () => (
+  <div className="p-3">
+    <SkeletonLine className="h-8 w-40" />
+  </div>
+);
+
+// Product grid skeleton for wishlist
+const WishlistGridSkeleton = ({ productCount = 4 }) => {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-5">
+      {Array.from({ length: productCount }).map((_, i) => (
+        <ProductCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+};
+
+const WishlistLoadingSkeleton = () => {
+  return (
+    <main 
+      className="p-5 md:p-20"
+      role="status"
+      aria-label="Loading wishlist"
+    >
+      <WishlistHeaderSkeleton />
+      <WishlistGridSkeleton />
+    </main>
+  );
+};
+
+export default WishlistLoadingSkeleton;


### PR DESCRIPTION
## Summary

Added loading skeleton components to improve user experience while pages are loading.

## Changes

- **Catalog page** (): Added category card skeletons with animated pulse effect
- **Search page** (): Added search header and product grid skeletons  
- **Wishlist page** (): Added wishlist header and product card skeletons

## Why it matters

Loading skeletons provide visual feedback to users while content is being fetched, reducing perceived wait time and improving the overall user experience. This follows the same pattern already used in the product detail page (loading.jsx).

## Limitations

- Uses existing ProductCardSkeleton component from shared/ui/skeleton
- Skeleton cards show fixed number of items (matching typical content count)

## Testing

- Build passes successfully
- All routes generate correctly