### PR TITLE
feat: add language switcher component

### DIFF
--- a/documentation/roadmap/README.md
+++ b/documentation/roadmap/README.md
@@ -276,6 +276,9 @@ A full-featured Next.js e-commerce platform with multi-language support (i18n), 
 ### 7.3.2026
 - Fixed: Multiple bugs in cart checkout flow - removed empty try-catch blocks, fixed typo in function name, added null check for product images, simplified redundant logic in wishlist component (PR #51)
 
+### 8.3.2026
+- Added: Loading skeletons for catalog, search, and wishlist pages - created loading.jsx files with animated skeleton UI components for better UX while pages load (PR #66)
+
 ### 5.3.2026
 - Fixed: Search API average rating - enabled reviews in query, added avg_rating and review_count to search results, enabled minRating filter (PR #35)
 

--- a/documentation/roadmap/README.md
+++ b/documentation/roadmap/README.md
@@ -278,6 +278,8 @@ A full-featured Next.js e-commerce platform with multi-language support (i18n), 
 
 ### 8.3.2026
 - Added: Loading skeletons for catalog, search, and wishlist pages - created loading.jsx files with animated skeleton UI components for better UX while pages load (PR #66)
+- Added: Language Switcher component - created reusable LanguageSwitcher with support for EN, RU, FA languages, added to DesktopHeader and Auth page
+- Added: Theme and Language switchers to Auth page - users can now switch language and theme while on login/register page
 
 ### 5.3.2026
 - Fixed: Search API average rating - enabled reviews in query, added avg_rating and review_count to search results, enabled minRating filter (PR #35)

--- a/src/app/[locale]/catalog/loading.jsx
+++ b/src/app/[locale]/catalog/loading.jsx
@@ -1,0 +1,38 @@
+"use client";
+
+import React from "react";
+
+// Reusable skeleton component
+const SkeletonCard = () => (
+  <div className="animate-pulse bg-surface border border-border rounded-xl p-4 flex flex-col items-center">
+    <div className="w-full h-32 bg-border rounded-lg mb-4" />
+    <div className="h-5 bg-border rounded w-3/4 mb-2" />
+    <div className="h-4 bg-border rounded w-1/2" />
+  </div>
+);
+
+// Category card skeleton for catalog page
+const CategoryCardSkeleton = () => (
+  <div className="animate-pulse bg-surface border border-border rounded-xl p-6 flex flex-col items-center justify-center min-h-[200px]">
+    <div className="w-20 h-20 bg-border rounded-full mb-4" />
+    <div className="h-6 bg-border rounded w-24 mb-2" />
+    <div className="h-4 bg-border rounded w-16" />
+  </div>
+);
+
+const CatalogLoadingSkeleton = () => {
+  return (
+    <main 
+      className="h-full grid grid-cols-2 md:grid-cols-5 gap-10 p-5 md:p-20"
+      role="status"
+      aria-label="Loading categories"
+    >
+      {/* Show 10 skeleton cards to match the 10 categories */}
+      {Array.from({ length: 10 }).map((_, i) => (
+        <CategoryCardSkeleton key={i} />
+      ))}
+    </main>
+  );
+};
+
+export default CatalogLoadingSkeleton;

--- a/src/app/[locale]/search/loading.jsx
+++ b/src/app/[locale]/search/loading.jsx
@@ -1,0 +1,46 @@
+"use client";
+
+import React from "react";
+import ProductCardSkeleton from "@/shared/ui/skeleton/ui/ProductCardSkeleton";
+
+// Reusable skeleton line component
+const SkeletonLine = ({ className = "" }) => (
+  <div className={`bg-surface animate-pulse rounded ${className}`} />
+);
+
+// Search page header skeleton
+const SearchHeaderSkeleton = () => (
+  <div className="p-5 md:p-10">
+    <div className="flex items-center gap-4 mb-6">
+      <SkeletonLine className="h-8 w-48" />
+      <SkeletonLine className="h-6 w-24" />
+    </div>
+    <SkeletonLine className="h-5 w-80" />
+  </div>
+);
+
+// Product grid skeleton for search results
+const SearchResultsSkeleton = ({ productCount = 8 }) => {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-5 p-5 md:p-10 pt-0">
+      {Array.from({ length: productCount }).map((_, i) => (
+        <ProductCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+};
+
+const SearchLoadingSkeleton = () => {
+  return (
+    <main 
+      className="min-h-screen"
+      role="status"
+      aria-label="Loading search results"
+    >
+      <SearchHeaderSkeleton />
+      <SearchResultsSkeleton />
+    </main>
+  );
+};
+
+export default SearchLoadingSkeleton;

--- a/src/app/[locale]/wishlist/loading.jsx
+++ b/src/app/[locale]/wishlist/loading.jsx
@@ -1,0 +1,42 @@
+"use client";
+
+import React from "react";
+import ProductCardSkeleton from "@/shared/ui/skeleton/ui/ProductCardSkeleton";
+
+// Reusable skeleton line component
+const SkeletonLine = ({ className = "" }) => (
+  <div className={`bg-surface animate-pulse rounded ${className}`} />
+);
+
+// Wishlist page header skeleton
+const WishlistHeaderSkeleton = () => (
+  <div className="p-3">
+    <SkeletonLine className="h-8 w-40" />
+  </div>
+);
+
+// Product grid skeleton for wishlist
+const WishlistGridSkeleton = ({ productCount = 4 }) => {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-5">
+      {Array.from({ length: productCount }).map((_, i) => (
+        <ProductCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+};
+
+const WishlistLoadingSkeleton = () => {
+  return (
+    <main 
+      className="p-5 md:p-20"
+      role="status"
+      aria-label="Loading wishlist"
+    >
+      <WishlistHeaderSkeleton />
+      <WishlistGridSkeleton />
+    </main>
+  );
+};
+
+export default WishlistLoadingSkeleton;

--- a/src/features/auth/ui/AuthFormLayout.jsx
+++ b/src/features/auth/ui/AuthFormLayout.jsx
@@ -4,6 +4,7 @@ import LoginForm from "./forms/LoginForm";
 import RegisterForm from "./forms/RegisterForm";
 import OAuthForm from "./OAuthForm/OAuthForm";
 import { useTranslations } from "next-intl";
+import { LanguageSwitcher, ThemeSwitcher } from "@/widgets/header/ui";
 
 const AuthFormLayout = () => {
   const t = useTranslations("auth");
@@ -38,6 +39,12 @@ const AuthFormLayout = () => {
           >
             {form === "login" ? tLogin("register") : tRegister("login")}
           </button>
+        </div>
+
+        {/* Language and Theme Switchers */}
+        <div className="flex items-center justify-center gap-4 mt-4 pt-4 border-t border-border">
+          <LanguageSwitcher variant="inline" />
+          <ThemeSwitcher />
         </div>
       </div>
 

--- a/src/widgets/header/ui/LanguageSwitcher.jsx
+++ b/src/widgets/header/ui/LanguageSwitcher.jsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Globe } from "lucide-react";
+import { useRouter, usePathname } from "@/shared/i18n";
+
+const languages = [
+  { id: "en", label: "English", flag: "🇺🇸" },
+  { id: "ru", label: "Русский", flag: "🇷🇺" },
+  { id: "fa", label: "فارسی", flag: "🇮🇷" },
+];
+
+const LanguageSwitcher = ({ variant = "dropdown" }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [currentLocale, setCurrentLocale] = useState("en");
+  const [mounted, setMounted] = useState(false);
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    // Get current locale from pathname
+    const pathParts = pathname.split("/");
+    const locale = pathParts[1];
+    if (languages.some((lang) => lang.id === locale)) {
+      setCurrentLocale(locale);
+    }
+    setMounted(true);
+  }, [pathname]);
+
+  const handleLanguageChange = (locale) => {
+    // Replace the locale in the pathname
+    const pathParts = pathname.split("/");
+    pathParts[1] = locale;
+    const newPath = pathParts.join("/");
+    
+    router.push(newPath);
+    setIsOpen(false);
+  };
+
+  const currentLang = languages.find((l) => l.id === currentLocale) || languages[0];
+
+  // Prevent hydration mismatch
+  if (!mounted) {
+    return (
+      <div className="p-2">
+        <Globe className="w-5 h-5" />
+      </div>
+    );
+  }
+
+  if (variant === "inline") {
+    // Inline version for auth page footer
+    return (
+      <div className="flex items-center gap-2">
+        <Globe className="w-4 h-4" />
+        <select
+          value={currentLocale}
+          onChange={(e) => handleLanguageChange(e.target.value)}
+          className="bg-transparent border-none text-sm focus:outline-none cursor-pointer"
+        >
+          {languages.map((lang) => (
+            <option key={lang.id} value={lang.id} className="bg-surface">
+              {lang.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    );
+  }
+
+  // Dropdown version for header
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="p-2 rounded-lg hover:bg-border/50 transition-colors flex items-center gap-2"
+        aria-label="Switch language"
+        aria-haspopup="true"
+        aria-expanded={isOpen}
+      >
+        <Globe />
+        <span className="text-xs">{currentLang.flag}</span>
+      </button>
+
+      {isOpen && (
+        <>
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => setIsOpen(false)}
+            aria-hidden="true"
+          />
+          <div 
+            className="absolute right-0 top-full mt-2 w-40 bg-surface border border-border rounded-lg shadow-lg z-50 overflow-hidden"
+            role="menu"
+            aria-label="Language options"
+          >
+            {languages.map((lang) => (
+              <button
+                key={lang.id}
+                onClick={() => handleLanguageChange(lang.id)}
+                className={`w-full px-4 py-2 flex items-center gap-2 hover:bg-border/50 transition-colors ${
+                  currentLocale === lang.id ? "bg-primary/10 text-primary" : ""
+                }`}
+                role="menuitem"
+              >
+                <span className="text-lg">{lang.flag}</span>
+                <span className="text-sm">{lang.label}</span>
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default LanguageSwitcher;

--- a/src/widgets/header/ui/desktop/DesktopHeader.jsx
+++ b/src/widgets/header/ui/desktop/DesktopHeader.jsx
@@ -11,7 +11,7 @@ import { Link, usePathname } from "@/shared/i18n";
 import { useTranslations, useLocale } from "next-intl";
 import { UserInfoModal } from "@/entities/user";
 import ProductSearch from "@/features/search/ui/ProductSearch";
-import { ShoppingCartButton, WishlistButton, Cyber, ThemeSwitcher } from "../index";
+import { ShoppingCartButton, WishlistButton, Cyber, ThemeSwitcher, LanguageSwitcher } from "../index";
 
 const routes = [
   { name: "Home", path: "/" },
@@ -62,6 +62,7 @@ export const DesktopHeader = () => {
           <Suspense fallback={<ShoppingCart />}>
             <ShoppingCartButton />
           </Suspense>
+          <LanguageSwitcher />
           <ThemeSwitcher />
           <UserInfoModal />
         </div>

--- a/src/widgets/header/ui/index.js
+++ b/src/widgets/header/ui/index.js
@@ -3,3 +3,4 @@ export { default as WishlistButton } from "./wishlistButton";
 export { default as NavLink } from "./NavLink";
 export { default as Cyber } from "./cyberIcon";
 export { default as ThemeSwitcher } from "./ThemeSwitcher";
+export { default as LanguageSwitcher } from "./LanguageSwitcher";


### PR DESCRIPTION

## Summary

Implemented a reusable LanguageSwitcher component and integrated it into the header and auth page.

## Changes

1. **Created LanguageSwitcher component** ()
   - Supports 3 languages: English, Russian, Persian
   - Two variants: dropdown (for header) and inline (for auth page)
   - Uses next-intl for locale routing
   
2. **Updated DesktopHeader** - Added LanguageSwitcher to the header icons section

3. **Updated AuthFormLayout** - Added both LanguageSwitcher (inline) and ThemeSwitcher to the auth page footer

## Why this improves the product

- Users can now easily switch between supported languages (EN, RU, FA)
- Language switcher is available on both the main site header and auth page
- Theme switcher is now also available on auth page (was missing)
- Improves international user experience and accessibility

## Limitations

- Mobile header remains compact without language switcher (can be added later)
- Persian (FA) locale routing may need middleware update (currently matcher only covers en/ru)
