### PR TITLE
feat: add product stock indicator

### DIFF
--- a/documentation/roadmap/README.md
+++ b/documentation/roadmap/README.md
@@ -285,4 +285,7 @@ A full-featured Next.js e-commerce platform with multi-language support (i18n), 
 ### 8.3.2026
 - Fixed: Wishlist toast message showing opposite action - when adding to wishlist showed "remove" and vice versa (PR #61)
 
+### 8.3.2026
+- Added: Product stock indicator - displays stock status badge on product cards (In Stock/Low Stock/Out of Stock), disables Buy Now button for out of stock products (PR #68)
+
 (repeatable section)

--- a/src/entities/product/ProductCard/ProductCard.jsx
+++ b/src/entities/product/ProductCard/ProductCard.jsx
@@ -17,6 +17,23 @@ const ProductCard = ({ data, otherInfo }) => {
     );
   }
 
+  // Stock indicator logic
+  const stockQuantity = data.stock_quantity || 0;
+  const isInStock = stockQuantity > 0;
+  const isLowStock = stockQuantity > 0 && stockQuantity <= 5;
+
+  const getStockDisplay = () => {
+    if (!isInStock) {
+      return { text: t("outOfStock"), className: "text-red-500 bg-red-50" };
+    }
+    if (isLowStock) {
+      return { text: `${t("onlyLeft")} ${stockQuantity}`, className: "text-orange-600 bg-orange-50" };
+    }
+    return { text: t("inStock"), className: "text-green-600 bg-green-50" };
+  };
+
+  const stockDisplay = getStockDisplay();
+
   return (
     <div className="group relative flex flex-col items-center justify-between rounded-2xl bg-card p-6 shadow-md transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl">
       {/* Like button */}
@@ -26,6 +43,11 @@ const ProductCard = ({ data, otherInfo }) => {
           productId={data.product_id}
           variantId={data.variant_id}
         />
+      </div>
+
+      {/* Stock indicator badge */}
+      <div className={`absolute z-20 top-4 left-4 px-2 py-1 rounded-full text-xs font-medium ${stockDisplay.className}`}>
+        {stockDisplay.text}
       </div>
 
       {/* Image */}
@@ -55,9 +77,14 @@ const ProductCard = ({ data, otherInfo }) => {
       {/* Button */}
       <button
         onClick={handleClick}
-        className="mt-4 w-[140px] rounded-xl bg-button px-4 py-2 text-button-text transition-all duration-300 hover:opacity-80"
+        disabled={!isInStock}
+        className={`mt-4 w-[140px] rounded-xl px-4 py-2 transition-all duration-300 ${
+          isInStock 
+            ? "bg-button text-button-text hover:opacity-80" 
+            : "bg-gray-400 text-white cursor-not-allowed"
+        }`}
       >
-        {t("buyNow")}
+        {isInStock ? t("buyNow") : t("outOfStock")}
       </button>
     </div>
   );

--- a/src/entities/product/ProductCard/ProductCard.jsx
+++ b/src/entities/product/ProductCard/ProductCard.jsx
@@ -6,6 +6,17 @@ import { AddToWishListCom } from "../../../features/add-to-wishlist/ui/AddToWish
 import { useRouter } from "@/shared/i18n";
 import { useTranslations } from "next-intl";
 
+// Stock indicator logic - moved outside component for performance
+const getStockDisplay = (stockQuantity, translations) => {
+  if (stockQuantity <= 0) {
+    return { text: translations("outOfStock"), className: "text-red-500 bg-red-50" };
+  }
+  if (stockQuantity <= 5) {
+    return { text: `${translations("onlyLeft")} ${stockQuantity}`, className: "text-orange-600 bg-orange-50" };
+  }
+  return { text: translations("inStock"), className: "text-green-600 bg-green-50" };
+};
+
 const ProductCard = ({ data, otherInfo }) => {
   const t = useTranslations("product");
   const router = useRouter();
@@ -17,22 +28,10 @@ const ProductCard = ({ data, otherInfo }) => {
     );
   }
 
-  // Stock indicator logic
-  const stockQuantity = data.stock_quantity || 0;
+  // Handle negative stock values safely
+  const stockQuantity = Math.max(0, data.stock_quantity || 0);
   const isInStock = stockQuantity > 0;
-  const isLowStock = stockQuantity > 0 && stockQuantity <= 5;
-
-  const getStockDisplay = () => {
-    if (!isInStock) {
-      return { text: t("outOfStock"), className: "text-red-500 bg-red-50" };
-    }
-    if (isLowStock) {
-      return { text: `${t("onlyLeft")} ${stockQuantity}`, className: "text-orange-600 bg-orange-50" };
-    }
-    return { text: t("inStock"), className: "text-green-600 bg-green-50" };
-  };
-
-  const stockDisplay = getStockDisplay();
+  const stockDisplay = getStockDisplay(stockQuantity, t);
 
   return (
     <div className="group relative flex flex-col items-center justify-between rounded-2xl bg-card p-6 shadow-md transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl">
@@ -45,8 +44,11 @@ const ProductCard = ({ data, otherInfo }) => {
         />
       </div>
 
-      {/* Stock indicator badge */}
-      <div className={`absolute z-20 top-4 left-4 px-2 py-1 rounded-full text-xs font-medium ${stockDisplay.className}`}>
+      {/* Stock indicator badge - positioned at bottom-left to avoid conflicts with other badges */}
+      <div 
+        className={`absolute z-20 bottom-4 left-4 px-2 py-1 rounded-full text-xs font-medium ${stockDisplay.className}`}
+        aria-label={stockDisplay.text}
+      >
         {stockDisplay.text}
       </div>
 
@@ -81,7 +83,7 @@ const ProductCard = ({ data, otherInfo }) => {
         className={`mt-4 w-[140px] rounded-xl px-4 py-2 transition-all duration-300 ${
           isInStock 
             ? "bg-button text-button-text hover:opacity-80" 
-            : "bg-gray-400 text-white cursor-not-allowed"
+            : "bg-muted text-card opacity-50 cursor-not-allowed"
         }`}
       >
         {isInStock ? t("buyNow") : t("outOfStock")}

--- a/src/shared/i18n/json/en.json
+++ b/src/shared/i18n/json/en.json
@@ -254,6 +254,9 @@
   "product": {
     "notFound": "Product not found",
     "buyNow": "Buy Now",
+    "inStock": "In Stock",
+    "outOfStock": "Out of Stock",
+    "onlyLeft": "Only",
     "selectColor": "Select color",
     "specifications": "Product Specifications",
     "addToWishlist": "Add to Wishlist",

--- a/src/shared/i18n/json/fa.json
+++ b/src/shared/i18n/json/fa.json
@@ -254,6 +254,9 @@
   "product": {
     "notFound": "محصول یافت نشد",
     "buyNow": "خرید کنید",
+    "inStock": "موجود",
+    "outOfStock": "ناموجود",
+    "onlyLeft": "فقط",
     "selectColor": "رنگ را انتخاب کنید",
     "specifications": "مشخصات محصول",
     "addToWishlist": "افزودن به علاقه‌مندی‌ها",

--- a/src/shared/i18n/json/ru.json
+++ b/src/shared/i18n/json/ru.json
@@ -258,6 +258,9 @@
   "product": {
     "notFound": "Товар не найден",
     "buyNow": "Купить сейчас",
+    "inStock": "В наличии",
+    "outOfStock": "Нет в наличии",
+    "onlyLeft": "Осталось",
     "selectColor": "Выберите цвет",
     "specifications": "Характеристики товара",
     "addToWishlist": "Добавить в список желаний",


### PR DESCRIPTION

## Summary

Added a stock indicator to product cards showing availability status.

## Changes

- **Stock Badge**: Shows "In Stock" (green), "Only X left" (orange for 5 or fewer), or "Out of Stock" (red) on product cards
- **Buy Button**: Disabled for out of stock products, shows "Out of Stock" text instead
- **Translations**: Added new translation keys for en, ru, fa languages

## Why This Improves the Product

- Users can instantly see product availability without clicking into the product detail
- Prevents frustration from discovering out-of-stock items during checkout
- Creates urgency for low-stock items (showing "Only X left")
- Improves overall shopping experience and reduces cart abandonment

## Feature Area

Product cards - the most visible element in the e-commerce flow

## ✅ Fixed Review Issues

- Fixed: Badge positioning conflict - moved from top-left to bottom-left to avoid overlap with other badges (like wishlist, sale badges)
- Fixed: Negative stock handling - now uses Math.max(0, stock_quantity) to safely handle negative values
- Improved: Performance - moved getStockDisplay function outside the component to avoid recreation on every render
- Improved: Accessibility - added aria-label to stock badge for screen readers
- Improved: Button styling - now uses CSS variables (bg-muted, text-card) instead of hardcoded colors for disabled state