### PR TITLE
Fix: Add proper error logging to empty catch blocks (#83)

### DIFF
--- a/src/app/api/products/related/route.js
+++ b/src/app/api/products/related/route.js
@@ -100,7 +100,8 @@ export async function GET(req) {
         headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" }
       });
     } catch (fallbackError) {
-      console.error("Fallback query failed:", fallbackError);
+      // Fallback failed - log at warn level since it's a recovery path
+      console.warn("Fallback query for related products failed:", fallbackError);
       return NextResponse.json([], { 
         status: 200,
         headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" }

--- a/src/app/api/products/related/route.js
+++ b/src/app/api/products/related/route.js
@@ -99,7 +99,8 @@ export async function GET(req) {
         status: 200,
         headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" }
       });
-    } catch {
+    } catch (fallbackError) {
+      console.error("Fallback query failed:", fallbackError);
       return NextResponse.json([], { 
         status: 200,
         headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" }

--- a/src/features/add-to-cart/model/handleCartQuantityChangeOnClient.js
+++ b/src/features/add-to-cart/model/handleCartQuantityChangeOnClient.js
@@ -25,7 +25,8 @@ export async function handleCartQuantityChange({ setLoading = () => {} , setCoun
         setAdded(res.item);
         if (!res.item)
           throw new Error("Something gone wrong while sending request");
-      } catch {
+      } catch (error) {
+        console.error("Cart quantity change error:", error);
         setCounter((s) => s - 1);
         toast.error("Something gone wrong while sending request");
       } finally {
@@ -50,7 +51,8 @@ export async function handleCartQuantityChange({ setLoading = () => {} , setCoun
 
         if (res?.success)
           throw new Error("Something gone wrong while sending request");
-      } catch {
+      } catch (error) {
+        console.error("Cart quantity change error:", error);
         setCounter((s) => s + 1);
         toast.error("Something gone wrong while sending request");
       } finally {
@@ -69,7 +71,8 @@ export async function handleCartQuantityChange({ setLoading = () => {} , setCoun
         }
         if (!res?.success)
           throw new Error("Something gone wrong while sending request");
-      } catch {
+      } catch (error) {
+        console.error("Cart delete error:", error);
         toast.error("Something gone wrong while sending request");
       } finally {
         setLoading(false);


### PR DESCRIPTION

## ✅ What was done
- Added `console.error` logging to all empty catch blocks in `handleCartQuantityChangeOnClient.js` (3 locations)
- Added `console.error` logging to fallback catch block in `related/route.js`
- Error objects are now captured and logged, enabling debugging when cart operations fail

## 🧠 Why it matters
- **Debugging difficulty**: When cart operations fail, the actual error is now logged instead of being lost
- **Silent failures**: Developers can now see what actually failed in the console
- **Production issues**: Real errors can now be diagnosed through console logs or error tracking

## 🔗 Related Issues
- Closes #83

## ⚠️ Notes
- No breaking changes - only adds error logging
- Build passes successfully

## ✅ Fixed Review Issues

- **Improved**: Changed fallback error logging in `related/route.js` from `console.error` to `console.warn` since fallback failure is not a critical error (recovery path worked as intended)
