### PR TITLE
Fix: Remove profanity from admin page (#86)

### DIFF
--- a/src/app/[locale]/admin/page.jsx
+++ b/src/app/[locale]/admin/page.jsx
@@ -18,7 +18,7 @@ export const metadata = {
 };
 
 const page = async () => {
-  return <div>admin page mazafucker</div>;
+  return <div>Admin Dashboard - Coming Soon</div>;
 };
 
 export default page;


### PR DESCRIPTION
## ✅ What was done
- Removed inappropriate language ("mazafucker") from admin page source code
- Replaced with professional placeholder text: "Admin Dashboard - Coming Soon"

## 🧠 Why it matters
- Inappropriate language was visible in production admin page source code
- This reflects poorly on code quality and professionalism
- Clean, professional placeholder text is appropriate for an admin dashboard under development

## 🔗 Related Issues
- Closes #86

## ⚠️ Notes
- This is a simple text replacement fix
- The admin page is a placeholder - full admin dashboard implementation would be a separate feature