### PR TITLE
Fix: Add try/catch to remaining API routes (#92)

### DIFF
--- a/src/app/api/orders/route.js
+++ b/src/app/api/orders/route.js
@@ -3,25 +3,33 @@ import prisma from "../../../../prisma/client";
 import { toSafeJson } from "../../../../prisma/funcs";
 import { getToken } from "next-auth/jwt";
 
-export let GET = async (req) => {
+export async function GET(req) {
     const user = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });  
 
     if (!user) {
         return new NextResponse(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
     }
 
-    const orders = await prisma.orders.findMany({
-        where: {
-            user_id: user.id
-        },
-        include: {
-            order_items: {
-                include: {
-                    product_variants: true
+    try {
+        const orders = await prisma.orders.findMany({
+            where: {
+                user_id: user.id
+            },
+            include: {
+                order_items: {
+                    include: {
+                        product_variants: true
+                    }
                 }
             }
-        }
-    })
+        })
 
-    return NextResponse.json({ data: toSafeJson(orders) , status: 200 })
+        return NextResponse.json({ data: toSafeJson(orders) , status: 200 })
+    } catch (error) {
+        console.error("API error:", error);
+        return NextResponse.json(
+            { error: "Failed to fetch orders" },
+            { status: 500 },
+        );
+    }
 }

--- a/src/app/api/products/images/route.js
+++ b/src/app/api/products/images/route.js
@@ -2,16 +2,24 @@ import { NextResponse } from "next/server";
 import prisma from "../../../../../prisma/client";
 import { toSafeJson } from "../../../../../prisma/funcs";
 
-export let GET = async (req, { params }) => {
+export async function GET(req, { params }) {
   const searchParams = req.nextUrl.searchParams;
   const product_id = searchParams.get("productId");
   // const variant_id = searchParams.get("variantId");
  
 
 
-  const specs = await prisma.product_images.findMany({
-    where: { product_id: product_id || undefined},
-  });
+  try {
+      const specs = await prisma.product_images.findMany({
+        where: { product_id: product_id || undefined},
+      });
 
-  return NextResponse.json({ data: toSafeJson(specs) });
+      return NextResponse.json({ data: toSafeJson(specs) });
+  } catch (error) {
+      console.error("API error:", error);
+      return NextResponse.json(
+          { error: "Failed to fetch product images" },
+          { status: 500 },
+      );
+  }
 };

--- a/src/app/api/products/specs/route.js
+++ b/src/app/api/products/specs/route.js
@@ -2,10 +2,19 @@ import { NextResponse } from "next/server"
 import prisma from "../../../../../prisma/client"
 import { toSafeJson } from "../../../../../prisma/funcs"
 
-export let GET = async (req , { params }) => {
+export async function GET(req , { params }) {
     const searchParams = req.nextUrl.searchParams;
     const product_id = searchParams.get("productId")
-    const specs = await prisma.product_specs.findMany({where: {product_id: product_id ? product_id : undefined}})
+    
+    try {
+        const specs = await prisma.product_specs.findMany({where: {product_id: product_id ? product_id : undefined}})
 
-    return NextResponse.json({ data: toSafeJson(specs) })
+        return NextResponse.json({ data: toSafeJson(specs) })
+    } catch (error) {
+        console.error("API error:", error);
+        return NextResponse.json(
+            { error: "Failed to fetch product specs" },
+            { status: 500 },
+        );
+    }
 }


### PR DESCRIPTION
## ✅ What was done
- Added try/catch error handling to 3 API routes that were missing it:
  - `src/app/api/orders/route.js`
  - `src/app/api/products/images/route.js`
  - `src/app/api/products/specs/route.js`

## 🧠 Why it matters
- Prevents server crashes from unhandled database errors
- Returns proper 500 error responses with meaningful messages to clients
- Improves debugging with console.error logging
- Follows the same pattern already implemented in other API routes

## 🔗 Related Issues
- Closes #92

## ⚠️ Notes
- This is a follow-up to issue #59 which fixed some routes but missed these three