### PR TITLE
feat: add recently viewed products feature

### DIFF
--- a/documentation/roadmap/README.md
+++ b/documentation/roadmap/README.md
@@ -230,7 +230,7 @@ A full-featured Next.js e-commerce platform with multi-language support (i18n), 
 
 ---
 
-## ➕ Future Additions (EMPTY TEMPLATE — KEEP THIS)
+## ➕ Future Additions (EMPTY TEMPLATE - KEEP THIS)
 
 ### 🧠 Planned Features
 - [ ] Feature name:
@@ -254,20 +254,20 @@ A full-featured Next.js e-commerce platform with multi-language support (i18n), 
 
 - [x] On the search page, when we search for products, the addition to the favorite ones does not work in the product card. (Fixed in PR #20 and subsequent improvements)
 
-- [x] On the back-end API side of the search The system that considers the average rating does not work. (Fixed in PR #35) 
+- [x] On the back-end API side of the search The system that considers the average rating does not work. (Fixed in PR #35)
 ---
- 
+
 ## 🧪 Testing Roadmap
 
 - [ ] **Automated testing setup**
   - Description: Follow the detailed checklist in `documentation/test/README.md` for per-layer/component coverage.
-  - Priority: High — ensures future changes remain safe and makes agentic work reproducible.
+  - Priority: High - ensures future changes remain safe and makes agentic work reproducible.
   - Notes: The playbook is increasingly granular (shared, entities, features, widgets, API, CI and agent workflow). Update this section whenever a major milestone completes.
 
 
 ---
 
-## 📝 Development Log (EMPTY — FOR MANUAL USE)
+## 📝 Development Log (EMPTY - FOR MANUAL USE)
 
 ### [Date]
 - Added:
@@ -275,7 +275,7 @@ A full-featured Next.js e-commerce platform with multi-language support (i18n), 
 - Fixed:
 
 ### 29.2.2026
-- Added: Function for editing and removing user addresses in the system has been added. 
+- Added: Function for editing and removing user addresses in the system has been added.
 
 ### 1.3.2026
 - Fixed: Search page wishlist functionality - added proper authentication handling, auto-create wishlist for new users, fixed toast message for unauthenticated users
@@ -294,7 +294,7 @@ A full-featured Next.js e-commerce platform with multi-language support (i18n), 
 - Fixed: Search API average rating - enabled reviews in query, added avg_rating and review_count to search results, enabled minRating filter (PR #35)
 
 ### 6.3.2026
-- Added: Admin sidebar navigation - implemented AdminSidebar component with links to dashboard, products, orders, users, categories 
+- Added: Admin sidebar navigation - implemented AdminSidebar component with links to dashboard, products, orders, users, categories
 - Updated: Admin page placeholder - added basic admin dashboard page with metadata
 - Fix: NavLink active state - updated to use pathname for accurate active link highlighting
 - Added: Tests for shared helpers (`shared/lib/fetch` and `shared/utils/cx`) to exercise foundation coverage.
@@ -314,9 +314,12 @@ A full-featured Next.js e-commerce platform with multi-language support (i18n), 
 - Added: `leave-comment` action tests covering unauthorized flows and valid submissions calling `/api/products/comments`.
 - Added: `register` model test that hashes passwords before POSTing to `/api/auth/register`.
 - Added: `payment mock` form test that formats card/expiry inputs, shows coupon pricing, and advances the checkout step.
-- Added: `ProductSearch` component tests that exercise the debounce, result list, and “view all” navigation.
+- Added: `ProductSearch` component tests that exercise the debounce, result list, and "view all" navigation.
 - Added: Header widget test ensuring desktop/mobile fragments render together.
 - Added: Footer widget test verifying nav/copyright copy, cart page test that surfaces `OrderSummary`, and orders page test covering filters/table rows.
+
+### 11.3.2026
+- Added: Recently Viewed Products feature - tracks products user views and displays them on home page (PR #98)
 
 
 (repeatable section)

--- a/src/app/[locale]/admin/page.jsx
+++ b/src/app/[locale]/admin/page.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+export const metadata = {
+  title: "Admin Dashboard | Store Management",
+  description:
+    "Store administration panel. Manage products, orders, customers, and analytics from one centralized dashboard.",
+  robots: "noindex, nofollow",
+  openGraph: {
+    title: "Admin Dashboard | Store Management",
+    description: "Store administration panel for managing your e-commerce business.",
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Admin Dashboard | Store Management",
+    description: "Store administration panel.",
+  },
+};
+
+const page = async () => {
+  return <div>admin page mazafucker</div>;
+};
+
+export default page;

--- a/src/app/[locale]/catalog/[categoryId]/[variantId]/page.jsx
+++ b/src/app/[locale]/catalog/[categoryId]/[variantId]/page.jsx
@@ -8,6 +8,7 @@ import { ProductRatingStats } from "@/entities/rating";
 import { getServerSession } from "next-auth";
 import { authParams } from "@/app/api/auth/[...nextauth]/route";
 import { getTranslations } from "next-intl/server";
+import { ProductViewTracker } from "@/features/recently-viewed";
 
 export async function generateMetadata({ params }) {
   const { variantId } = await params;
@@ -64,6 +65,7 @@ const page = async ({ params }) => {
 
   return (
     <main className="md:px-4 h-full text-text w-full overflow-hidden p-5 md:p-20 flex flex-col">
+      <ProductViewTracker product={data} />
       <div className="w-full flex-col flex center pb-28 md:px-20 md:flex-row md:gap-10 gap-5">
         <Suspense>
           <Slider productId={productId} variantId={variantId} />

--- a/src/app/[locale]/page.jsx
+++ b/src/app/[locale]/page.jsx
@@ -29,30 +29,23 @@ export const metadata = {
 };
 
 import React, { Suspense } from "react";
-import { getTranslations } from "next-intl/server";
 import { Miniloader, ProductsRenderSkeleton } from "@/shared";
-import { Main, CategorySection, FeaturedProducts } from "@/features/home";
+import { Main, CategorySection } from "@/features/home";
 import { DragScrollContainer } from "@/shared/ui/ScrollContainer";
-import { RecentlyViewedProducts } from "@/features/recently-viewed";
+import { HomeProductShowcaseSection } from "@/widgets/home-product-showcase";
 
 const Page = async () => {
-  const t = await getTranslations("home");
-
   return (
-    <div className="mx-auto max-w-[1440px]">
+    <div className="mx-auto max-w-360">
       <Suspense fallback={<Miniloader />}>
         <Main />
       </Suspense>
       <Suspense fallback={<Miniloader />}>
         <CategorySection />
       </Suspense>
-      <div className="md:my-14 md:mx-40 text-text">
-        <h1 className="text-2xl font-bold my-6">{t("featuredProducts")}</h1>
-        <Suspense fallback={<ProductsRenderSkeleton productsCount={8} />}>
-          <FeaturedProducts />
-        </Suspense>
-      </div>
-      <RecentlyViewedProducts />
+      <Suspense fallback={<ProductsRenderSkeleton productsCount={8} />}>
+        <HomeProductShowcaseSection />
+      </Suspense>
       <DragScrollContainer />
     </div>
   );

--- a/src/app/[locale]/page.jsx
+++ b/src/app/[locale]/page.jsx
@@ -33,6 +33,7 @@ import { getTranslations } from "next-intl/server";
 import { Miniloader, ProductsRenderSkeleton } from "@/shared";
 import { Main, CategorySection, FeaturedProducts } from "@/features/home";
 import { DragScrollContainer } from "@/shared/ui/ScrollContainer";
+import { RecentlyViewedProducts } from "@/features/recently-viewed";
 
 const Page = async () => {
   const t = await getTranslations("home");
@@ -51,6 +52,7 @@ const Page = async () => {
           <FeaturedProducts />
         </Suspense>
       </div>
+      <RecentlyViewedProducts />
       <DragScrollContainer />
     </div>
   );

--- a/src/app/api/products/[variantId]/route.js
+++ b/src/app/api/products/[variantId]/route.js
@@ -22,12 +22,22 @@ export async function GET(req, { params }) {
         discount_percent: true,
         stock_quantity: true,
         variant_options: { select: { key: true, value: true } },
+        product_images: {
+          select: { url: true },
+          orderBy: { position: "asc" },
+          take: 1,
+        },
           products: {
           select: {
             id: true,
             name: true,
             description: true,
             created_at: true,
+            product_images: {
+              select: { url: true },
+              orderBy: { position: "asc" },
+              take: 1,
+            },
             categories: {
               select: {
                 id: true,

--- a/src/entities/product/ProductCard/ProductCard.jsx
+++ b/src/entities/product/ProductCard/ProductCard.jsx
@@ -9,105 +9,120 @@ import {
   getProductCreatedAt,
   getProductPriceInfo,
   getProductStockQuantity,
-  isProductInStock,
 } from "@/entities/product";
-import { StockIndicator } from "@/shared/ui/stock-indicator";
 import { useRouter } from "@/shared/i18n";
 import { useTranslations } from "next-intl";
 
-const ProductCard = ({ data, otherInfo }) => {
+const ProductCard = ({ data, otherInfo, contextLabel }) => {
   const t = useTranslations("product");
   const router = useRouter();
+
   if (!data) return <div>{t("notFound")}</div>;
 
   function handleClick() {
+    if (!data?.category_id || !data?.variant_id) return;
+
     router.push(
-      `/catalog/${data.category_id}/${data.variant_id}?product=${data.product_name}&variant=${data.variant_name}`,
+      `/catalog/${data.category_id}/${data.variant_id}?product=${encodeURIComponent(data.product_name || "")}&variant=${encodeURIComponent(data.variant_name || "")}`,
     );
   }
 
-  // Handle negative stock values safely
   const stockQuantity = getProductStockQuantity(data);
-  const isInStock = isProductInStock(data);
-
-  // Calculate discounted price if on sale (with null safety)
-  // Accept both snake_case (from server) and camelCase (possible client transforms)
+  const hasKnownStock = data?.stock_quantity != null;
+  const isInStock = !hasKnownStock || stockQuantity > 0;
   const createdAt = getProductCreatedAt(data);
   const { discountPercent, hasDiscount } = getProductPriceInfo(data);
+  const productName = data.product_name || t("notFound");
+  const variantName = data.variant_name || "";
+  const stockLabel = !hasKnownStock
+    ? null
+    : stockQuantity > 0
+      ? stockQuantity <= 5
+        ? `${t("onlyLeft")} ${stockQuantity}`
+        : t("inStock")
+      : t("outOfStock");
 
   return (
-    <div className="group relative flex flex-col items-center justify-between rounded-2xl bg-card p-6 shadow-md transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl">
-      {/* Product Badges (New / Sale) */}
-      <ProductBadges createdAt={createdAt} discountPercent={discountPercent} />
-
-      {/* Like button */}
-      <div className="absolute z-20 top-4 right-4">
-        <AddToWishListCom
-          wishlistInfo={otherInfo}
-          productId={data.product_id}
-          variantId={data.variant_id}
+    <article className="group relative flex h-full flex-col overflow-hidden rounded-[28px] border border-border/60 bg-card/90 shadow-[0_18px_60px_-28px_rgba(0,0,0,0.45)] backdrop-blur-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_25px_80px_-30px_rgba(59,130,246,0.25)]">
+      <div className="relative aspect-square overflow-hidden bg-linear-to-br from-surface via-surface/85 to-background/80">
+        <ProductBadges
+          createdAt={createdAt}
+          discountPercent={discountPercent}
         />
-      </div>
 
-      {/* Stock indicator badge - positioned at bottom-left to avoid conflicts with other badges */}
-      <StockIndicator
-        stockQuantity={stockQuantity}
-        lowStockThreshold={5}
-        onlyLeftLabel={t("onlyLeft")}
-        inStockLabel={t("inStock")}
-      />
+        <div className="absolute right-4 top-4 z-20 rounded-full border border-white/15 bg-background/75 p-2 text-text shadow-lg backdrop-blur-md">
+          <AddToWishListCom
+            wishlistInfo={otherInfo}
+            productId={data.product_id}
+            variantId={data.variant_id}
+          />
+        </div>
 
-      {/* Image */}
-      <div className="flex items-center justify-center w-full max-h-[220px] overflow-clip">
+        {stockLabel && (
+          <div className="absolute bottom-4 left-4 z-20 rounded-full border border-white/10 bg-black/45 px-3 py-1 text-xs font-medium text-white backdrop-blur-md">
+            {stockLabel}
+          </div>
+        )}
+
         <Image
           src={data.image_url || "/placeholder.png"}
-          alt={data.variant_name}
-          width={220}
-          height={220}
-          className="object-cover object-[top_center] h-full w-auto transition-transform duration-500 group-hover:scale-105"
+          alt={variantName || productName}
+          fill
+          sizes="(max-width: 768px) 70vw, (max-width: 1280px) 33vw, 25vw"
+          className="object-contain p-6 transition-transform duration-500 group-hover:scale-105"
         />
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-linear-to-t from-card via-card/50 to-transparent" />
       </div>
 
-      {/* Title */}
-      <h1 className="mt-3 z-20   drop-shadow-2xl text-[clamp(1rem,1.5vw,1.125rem)] text-center text-text leading-snug line-clamp-2">
-        {data.product_name} –{" "}
-        <span className="font-semibold text-text z-20">
-          {data.variant_name}
-        </span>
-      </h1>
+      <div className="flex flex-1 flex-col gap-4 p-5">
+        <div className="space-y-2">
+          {contextLabel && (
+            <p className="text-xs font-medium uppercase tracking-[0.24em] text-muted">
+              {contextLabel}
+            </p>
+          )}
+          <h3 className="line-clamp-2 text-lg font-semibold leading-tight text-text">
+            {productName}
+          </h3>
+          {variantName && (
+            <p className="line-clamp-1 text-sm text-muted">{variantName}</p>
+          )}
+        </div>
 
-      {/* Price */}
-      <ProductPrice
-        priceCents={data.price_cents}
-        discountPercent={discountPercent}
-        containerClassName="flex items-center gap-2 mt-1"
-        originalPriceClassName="text-lg font-bold text-muted line-through"
-        currentPriceClassName={`text-[clamp(1.25rem,2vw,1.5rem)] font-bold ${hasDiscount ? "text-red-500" : "text-text"}`}
-        currencySuffix=" $"
-      />
+        <div className="mt-auto flex flex-col gap-4">
+          <div className="space-y-1">
+            <ProductPrice
+              priceCents={data.price_cents}
+              discountPercent={discountPercent}
+              containerClassName="flex flex-wrap items-center gap-2"
+              originalPriceClassName="text-sm text-muted line-through"
+              currentPriceClassName={`text-2xl font-bold ${hasDiscount ? "text-red-500" : "text-text"}`}
+              currencySuffix=" $"
+            />
+            <p className="text-xs text-muted">{stockLabel || t("details")}</p>
+          </div>
 
-      {/* Action buttons - Quick Add + Buy Now */}
-      <div className="mt-4 flex">
-        {/* Quick Add to Cart button */}
-        <QuickAddToCart
-          variantId={data.variant_id}
-          productName={`${data.product_name} - ${data.variant_name}`}
-        />
+          <div className="flex items-center gap-3">
+            <QuickAddToCart
+              variantId={data.variant_id}
+              productName={`${productName}${variantName ? ` - ${variantName}` : ""}`}
+              disabled={hasKnownStock && !isInStock}
+              showLabel
+              className="flex-1 rounded-full border border-border/70 bg-background/60 px-4 py-3 text-text backdrop-blur-md hover:bg-background/80"
+            />
 
-        {/* Buy Now button */}
-        <button
-          onClick={handleClick}
-          disabled={!isInStock}
-          className={`w-25 rounded-r-xl px-4 py-2 transition-all duration-300 ${
-            isInStock
-              ? "bg-button text-button-text hover:opacity-80"
-              : "bg-muted text-card opacity-50 cursor-not-allowed"
-          }`}
-        >
-          {isInStock ? t("buyNow") : t("outOfStock")}
-        </button>
+            <button
+              type="button"
+              onClick={handleClick}
+              disabled={!data?.category_id || !data?.variant_id}
+              className="flex-1 rounded-full bg-button px-4 py-3 text-sm font-medium text-button-text transition-opacity hover:opacity-85 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {t("details")}
+            </button>
+          </div>
+        </div>
       </div>
-    </div>
+    </article>
   );
 };
 

--- a/src/entities/product/lib/productMeta.ts
+++ b/src/entities/product/lib/productMeta.ts
@@ -29,8 +29,9 @@ const getFieldValue = <T>(
 ) => {
   if (input && typeof input === "object") {
     for (const key of keys) {
-      if (key in input && input[key] != null) {
-        return input[key];
+      const obj = input as Record<string, unknown>;
+      if (key in obj && obj[key] != null) {
+        return obj[key];
       }
     }
   }
@@ -73,7 +74,7 @@ export const isProductNew = (
 
   if (!createdAt) return false;
 
-  const createdDate = new Date(createdAt);
+  const createdDate = new Date(createdAt as string | Date);
   if (Number.isNaN(createdDate.getTime())) return false;
 
   const now = new Date();

--- a/src/features/add-to-cart/ui/QuickAddToCart.jsx
+++ b/src/features/add-to-cart/ui/QuickAddToCart.jsx
@@ -6,7 +6,13 @@ import { toast } from "react-hot-toast";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 
-export function QuickAddToCart({ variantId, productName }) {
+export function QuickAddToCart({
+  variantId,
+  productName,
+  className = "",
+  showLabel = false,
+  disabled = false,
+}) {
   const t = useTranslations("cart");
   const tCommon = useTranslations("common");
   const [loading, setLoading] = useState(false);
@@ -16,7 +22,9 @@ export function QuickAddToCart({ variantId, productName }) {
 
   const handleClick = async () => {
     if (!user?.id) {
-      toast.error(tCommon("error") + ": Authorization required.", { icon: "🔐" });
+      toast.error(tCommon("error") + ": Authorization required.", {
+        icon: "🔐",
+      });
       return;
     }
 
@@ -24,7 +32,7 @@ export function QuickAddToCart({ variantId, productName }) {
     try {
       // Pass userId so cart is auto-created if needed
       const res = await addToCart(variantId, "add", null, user.id);
-      
+
       if (res?.error) {
         toast.error(res.error);
       } else if (res?.item) {
@@ -44,12 +52,14 @@ export function QuickAddToCart({ variantId, productName }) {
   return (
     <button
       onClick={handleClick}
-      disabled={loading || added}
-      className={` flex items-center justify-center gap-2 px-3 py-2 rounded-l-xl text-sm font-medium transition-all duration-300 ${
+      disabled={disabled || loading || added}
+      className={`flex items-center justify-center gap-2 px-3 py-2 rounded-l-xl text-sm font-medium transition-all duration-300 ${
         added
           ? "bg-green-600 text-white"
-          : "bg-button/30 text-button-text hover:opacity-80"
-      }`}
+          : disabled
+            ? "cursor-not-allowed bg-muted/40 text-muted"
+            : "bg-button/30 text-button-text hover:opacity-80"
+      } ${className}`}
       title={productName ? `Quick add: ${productName}` : "Quick add to cart"}
     >
       {loading ? (
@@ -59,6 +69,7 @@ export function QuickAddToCart({ variantId, productName }) {
       ) : (
         <ShoppingCart size={16} />
       )}
+      {showLabel && <span>{added ? t("added") : t("quickAdd")}</span>}
     </button>
   );
 }

--- a/src/features/home/index.js
+++ b/src/features/home/index.js
@@ -3,3 +3,4 @@ export { default as ResponsibleBanner } from "./ui/banners/ResponsibleBanner";
 export { default as CategorySection } from "./ui/CategorySection/Main";
 export { default as FeaturedProducts } from "./ui/CategorySection/FeaturedProducts";
 export { default as CategoryCard } from "./ui/CategorySection/CategoryCard";
+export { getFeaturedProducts } from "./model";

--- a/src/features/home/model/getFeaturedProducts.js
+++ b/src/features/home/model/getFeaturedProducts.js
@@ -1,0 +1,7 @@
+import { Fetch } from "@/shared/lib";
+
+export async function getFeaturedProducts(limit = 8) {
+  return Fetch(`/api/products?limit=${limit}&distinctProducts=true`);
+}
+
+export default getFeaturedProducts;

--- a/src/features/home/model/index.js
+++ b/src/features/home/model/index.js
@@ -1,0 +1,1 @@
+export { getFeaturedProducts } from "./getFeaturedProducts";

--- a/src/features/home/ui/CategorySection/FeaturedProducts.jsx
+++ b/src/features/home/ui/CategorySection/FeaturedProducts.jsx
@@ -1,12 +1,12 @@
 import React from "react";
 import ProductCard from "@/entities/product";
-import { Fetch } from "@/shared/lib";
 import { getTranslations } from "next-intl/server";
+import { getFeaturedProducts } from "@/features/home/model";
 
 const FeaturedProducts = async () => {
   const t = await getTranslations("common");
 
-  const res = await Fetch("/api/products?limit=8&distinctProducts=true");
+  const res = await getFeaturedProducts(8);
 
   if (!res) {
     return <div>{t("error")}</div>;

--- a/src/features/recently-viewed/index.js
+++ b/src/features/recently-viewed/index.js
@@ -1,0 +1,2 @@
+export { useRecentlyViewed } from "./model";
+export { RecentlyViewedProducts, ProductViewTracker } from "./ui";

--- a/src/features/recently-viewed/model/index.js
+++ b/src/features/recently-viewed/model/index.js
@@ -1,0 +1,1 @@
+export { useRecentlyViewed } from "./useRecentlyViewed";

--- a/src/features/recently-viewed/model/useRecentlyViewed.js
+++ b/src/features/recently-viewed/model/useRecentlyViewed.js
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+const STORAGE_KEY = "recently_viewed_products";
+const MAX_ITEMS = 10;
+
+/**
+ * Hook to manage recently viewed products in localStorage
+ * @returns {object} - recently viewed products array and add function
+ */
+export function useRecentlyViewed() {
+  const [recentlyViewed, setRecentlyViewed] = useState([]);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  // Load from localStorage on mount
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        setRecentlyViewed(parsed);
+      }
+    } catch (error) {
+      console.error("Failed to load recently viewed products:", error);
+    }
+    setIsLoaded(true);
+  }, []);
+
+  // Save to localStorage whenever recentlyViewed changes
+  useEffect(() => {
+    if (isLoaded) {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(recentlyViewed));
+      } catch (error) {
+        console.error("Failed to save recently viewed products:", error);
+      }
+    }
+  }, [recentlyViewed, isLoaded]);
+
+  const addToRecentlyViewed = useCallback((product) => {
+    if (!product || !product.variant_id) return;
+
+    setRecentlyViewed((prev) => {
+      // Remove if already exists (to move to front)
+      const filtered = prev.filter((item) => item.variant_id !== product.variant_id);
+
+      // Add to front with timestamp
+      const newItem = {
+        ...product,
+        viewedAt: Date.now(),
+      };
+
+      // Keep only MAX_ITEMS
+      const newList = [newItem, ...filtered].slice(0, MAX_ITEMS);
+
+      return newList;
+    });
+  }, []);
+
+  const clearRecentlyViewed = useCallback(() => {
+    setRecentlyViewed([]);
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch (error) {
+      console.error("Failed to clear recently viewed products:", error);
+    }
+  }, []);
+
+  const removeFromRecentlyViewed = useCallback((variantId) => {
+    setRecentlyViewed((prev) =>
+      prev.filter((item) => item.variant_id !== variantId)
+    );
+  }, []);
+
+  return {
+    recentlyViewed,
+    addToRecentlyViewed,
+    clearRecentlyViewed,
+    removeFromRecentlyViewed,
+    isLoaded,
+  };
+}
+
+export default useRecentlyViewed;

--- a/src/features/recently-viewed/ui/ProductViewTracker.jsx
+++ b/src/features/recently-viewed/ui/ProductViewTracker.jsx
@@ -11,16 +11,24 @@ const ProductViewTracker = ({ product }) => {
   const { addToRecentlyViewed } = useRecentlyViewed();
 
   useEffect(() => {
-    if (product && product.variant_id) {
+    const variantId = product?.variant_id ?? product?.id;
+
+    if (product && variantId) {
       // Extract the necessary product info for the recently viewed list
       const productInfo = {
-        variant_id: product.variant_id,
+        variant_id: variantId,
         product_id: product.products?.id || product.product_id,
         product_name: product.products?.name || product.product_name,
         variant_name: product.variant_name,
-        image_url: product.image_url,
+        image_url:
+          product.image_url ||
+          product.product_images?.[0]?.url ||
+          product.products?.product_images?.[0]?.url ||
+          null,
         price_cents: product.price_cents,
         discount_percent: product.discount_percent,
+        stock_quantity: product.stock_quantity,
+        created_at: product.products?.created_at || product.created_at,
         category_id: product.products?.categories?.id || product.category_id,
       };
 

--- a/src/features/recently-viewed/ui/ProductViewTracker.jsx
+++ b/src/features/recently-viewed/ui/ProductViewTracker.jsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRecentlyViewed } from "../model";
+
+/**
+ * Component to track when a product is viewed
+ * Add this to the product detail page to track views
+ */
+const ProductViewTracker = ({ product }) => {
+  const { addToRecentlyViewed } = useRecentlyViewed();
+
+  useEffect(() => {
+    if (product && product.variant_id) {
+      // Extract the necessary product info for the recently viewed list
+      const productInfo = {
+        variant_id: product.variant_id,
+        product_id: product.products?.id || product.product_id,
+        product_name: product.products?.name || product.product_name,
+        variant_name: product.variant_name,
+        image_url: product.image_url,
+        price_cents: product.price_cents,
+        discount_percent: product.discount_percent,
+        category_id: product.products?.categories?.id || product.category_id,
+      };
+
+      addToRecentlyViewed(productInfo);
+    }
+  }, [product, addToRecentlyViewed]);
+
+  // This component doesn't render anything
+  return null;
+};
+
+export default ProductViewTracker;

--- a/src/features/recently-viewed/ui/RecentlyViewedProducts.jsx
+++ b/src/features/recently-viewed/ui/RecentlyViewedProducts.jsx
@@ -1,0 +1,55 @@
+"use client";
+
+import React from "react";
+import { useTranslations } from "next-intl";
+import { useRecentlyViewed } from "../model";
+import { ProductCard } from "@/entities/product";
+import { ScrollContainer, DragScrollContainer } from "@/shared/ui/ScrollContainer";
+import { Miniloader } from "@/shared/ui/Loading";
+
+const RecentlyViewedProducts = () => {
+  const t = useTranslations("home");
+  const { recentlyViewed, isLoaded, clearRecentlyViewed } = useRecentlyViewed();
+
+  // Don't render on server or if no products
+  if (!isLoaded) {
+    return (
+      <div className="md:my-14 md:mx-40 text-text">
+        <h1 className="text-2xl font-bold my-6">{t("recentlyViewed")}</h1>
+        <Miniloader />
+      </div>
+    );
+  }
+
+  if (!recentlyViewed || recentlyViewed.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="md:my-14 md:mx-40 text-text">
+      <div className="flex items-center justify-between my-6">
+        <h1 className="text-2xl font-bold">{t("recentlyViewed")}</h1>
+        {recentlyViewed.length > 0 && (
+          <button
+            onClick={clearRecentlyViewed}
+            className="text-sm text-muted hover:text-text transition-colors underline"
+          >
+            {t("clearHistory")}
+          </button>
+        )}
+      </div>
+      
+      <DragScrollContainer>
+        <div className="flex gap-4 pb-4">
+          {recentlyViewed.map((product) => (
+            <div key={product.variant_id} className="flex-shrink-0 w-[280px]">
+              <ProductCard data={product} />
+            </div>
+          ))}
+        </div>
+      </DragScrollContainer>
+    </div>
+  );
+};
+
+export default RecentlyViewedProducts;

--- a/src/features/recently-viewed/ui/RecentlyViewedProducts.jsx
+++ b/src/features/recently-viewed/ui/RecentlyViewedProducts.jsx
@@ -4,7 +4,6 @@ import React from "react";
 import { useTranslations } from "next-intl";
 import { useRecentlyViewed } from "../model";
 import { ProductCard } from "@/entities/product";
-import { ScrollContainer, DragScrollContainer } from "@/shared/ui/ScrollContainer";
 import { Miniloader } from "@/shared/ui/Loading";
 
 const RecentlyViewedProducts = () => {
@@ -38,16 +37,19 @@ const RecentlyViewedProducts = () => {
           </button>
         )}
       </div>
-      
-      <DragScrollContainer>
-        <div className="flex gap-4 pb-4">
+
+      <div className="overflow-x-auto pb-2 md:overflow-visible">
+        <div className="flex gap-4 pb-4 md:grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 md:gap-6 md:pb-0">
           {recentlyViewed.map((product) => (
-            <div key={product.variant_id} className="flex-shrink-0 w-[280px]">
+            <div
+              key={product.variant_id}
+              className="w-70 min-w-70 shrink-0 md:w-auto md:min-w-0"
+            >
               <ProductCard data={product} />
             </div>
           ))}
         </div>
-      </DragScrollContainer>
+      </div>
     </div>
   );
 };

--- a/src/features/recently-viewed/ui/index.js
+++ b/src/features/recently-viewed/ui/index.js
@@ -1,0 +1,2 @@
+export { default as RecentlyViewedProducts } from "./RecentlyViewedProducts";
+export { default as ProductViewTracker } from "./ProductViewTracker";

--- a/src/shared/i18n/json/en.json
+++ b/src/shared/i18n/json/en.json
@@ -126,7 +126,9 @@
 
   "home": {
     "featuredProducts": "Featured Products",
-    "BrowseByCategory": "Browse By Category"
+    "BrowseByCategory": "Browse By Category",
+    "recentlyViewed": "Recently Viewed",
+    "clearHistory": "Clear History"
   },
 
   "cart": {

--- a/src/shared/i18n/json/en.json
+++ b/src/shared/i18n/json/en.json
@@ -128,7 +128,9 @@
     "featuredProducts": "Featured Products",
     "BrowseByCategory": "Browse By Category",
     "recentlyViewed": "Recently Viewed",
-    "clearHistory": "Clear History"
+    "clearHistory": "Clear History",
+    "productsShowcase": "Product Showcase",
+    "recentlyViewedEmpty": "Open a few product pages and they will appear here."
   },
 
   "cart": {

--- a/src/shared/i18n/json/fa.json
+++ b/src/shared/i18n/json/fa.json
@@ -128,7 +128,9 @@
     "featuredProducts": "محصولات ویژه",
     "BrowseByCategory": "دسته‌بندی بر اساس",
     "recentlyViewed": "محصولات بازدید شده",
-    "clearHistory": "پاک کردن تاریخچه"
+    "clearHistory": "پاک کردن تاریخچه",
+    "productsShowcase": "ویترین محصولات",
+    "recentlyViewedEmpty": "چند صفحه محصول را باز کنید تا اینجا نمایش داده شوند."
   },
 
   "cart": {

--- a/src/shared/i18n/json/fa.json
+++ b/src/shared/i18n/json/fa.json
@@ -126,7 +126,9 @@
 
   "home": {
     "featuredProducts": "محصولات ویژه",
-    "BrowseByCategory": "دسته‌بندی بر اساس"
+    "BrowseByCategory": "دسته‌بندی بر اساس",
+    "recentlyViewed": "محصولات بازدید شده",
+    "clearHistory": "پاک کردن تاریخچه"
   },
 
   "cart": {

--- a/src/shared/i18n/json/ru.json
+++ b/src/shared/i18n/json/ru.json
@@ -128,7 +128,9 @@
 
   "home": {
     "featuredProducts": "Рекомендуемые товары",
-    "BrowseByCategory": "Просмотр по категориям"
+    "BrowseByCategory": "Просмотр по категориям",
+    "recentlyViewed": "Недавно просмотренные",
+    "clearHistory": "Очистить историю"
   },
 
   "cart": {

--- a/src/shared/i18n/json/ru.json
+++ b/src/shared/i18n/json/ru.json
@@ -130,7 +130,9 @@
     "featuredProducts": "Рекомендуемые товары",
     "BrowseByCategory": "Просмотр по категориям",
     "recentlyViewed": "Недавно просмотренные",
-    "clearHistory": "Очистить историю"
+    "clearHistory": "Очистить историю",
+    "productsShowcase": "Витрина товаров",
+    "recentlyViewedEmpty": "Откройте несколько карточек товаров, и они появятся здесь."
   },
 
   "cart": {

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -4,4 +4,4 @@ export { ProductCardSkeleton, ProductsRenderSkeleton } from "./ui/skeleton";
 export { Miniloader, PageLoader } from "./ui/Loading";
 export { default as DragScrollContainer } from "./ui/ScrollContainer/ScrollContainer";
 export { Slider } from "./ui/slider";
-export { default as NavLink } from "./ui/NavLink/NavLink";
+export { default as NavLink } from "./ui/navlink/NavLink";

--- a/src/widgets/header/ui/NavLink.jsx
+++ b/src/widgets/header/ui/NavLink.jsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Link } from "@/shared/i18n";
+import { usePathname } from "next/navigation";
+
+const NavLink = ({ href, children , className}) => {
+  const pathname = usePathname();
+  const isActive = pathname == href; 
+
+  return (
+    <Link
+      href={href}
+      className={`${isActive ? "relative w-8 h-8 scale-250 bottom-4 rounded-full flex center text-primary-text bg-primary shadow-2xl animate-get-out" : ""} ${className} `}
+    >
+      {children}
+    </Link>
+  );
+};
+
+export default NavLink;

--- a/src/widgets/home-product-showcase/index.js
+++ b/src/widgets/home-product-showcase/index.js
@@ -1,0 +1,1 @@
+export { HomeProductShowcaseSection } from "./ui";

--- a/src/widgets/home-product-showcase/ui/HomeProductShowcaseClient.jsx
+++ b/src/widgets/home-product-showcase/ui/HomeProductShowcaseClient.jsx
@@ -1,0 +1,143 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import { ProductCard } from "@/entities/product";
+import { useRecentlyViewed } from "@/features/recently-viewed";
+
+const HomeProductShowcaseClient = ({ featuredProducts, featuredOtherInfo }) => {
+  const homeT = useTranslations("home");
+  const { recentlyViewed, isLoaded, clearRecentlyViewed } = useRecentlyViewed();
+  const [activeTab, setActiveTab] = useState("featured");
+
+  const tabs = useMemo(
+    () => [
+      { key: "featured", label: homeT("featuredProducts") },
+      { key: "recent", label: homeT("recentlyViewed") },
+    ],
+    [homeT],
+  );
+
+  const items = activeTab === "featured" ? featuredProducts : recentlyViewed;
+  const isRecentTab = activeTab === "recent";
+  const showRecentLoader = isRecentTab && !isLoaded;
+  const showRecentEmpty =
+    isRecentTab && isLoaded && recentlyViewed.length === 0;
+
+  return (
+    <section className="relative mx-5 my-14 overflow-hidden rounded-[36px] border border-border/60 bg-linear-to-br from-card via-card/95 to-surface/90 p-6 text-text shadow-[0_30px_120px_-40px_rgba(15,23,42,0.55)] md:mx-10 md:p-8 xl:mx-20">
+      <div className="pointer-events-none absolute -right-16 top-0 h-56 w-56 rounded-full bg-blue-500/10 blur-3xl" />
+      <div className="pointer-events-none absolute -left-20 bottom-0 h-52 w-52 rounded-full bg-fuchsia-500/10 blur-3xl" />
+
+      <div className="relative z-10 flex flex-col gap-5">
+        <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+          <div className="space-y-2">
+            <p className="text-xs font-medium uppercase tracking-[0.3em] text-muted">
+              {homeT("productsShowcase")}
+            </p>
+            <h2 className="text-2xl font-bold md:text-3xl">
+              {isRecentTab
+                ? homeT("recentlyViewed")
+                : homeT("featuredProducts")}
+            </h2>
+            <p className="max-w-2xl text-sm text-muted md:text-base">
+              {isRecentTab
+                ? homeT("recentlyViewed")
+                : homeT("featuredProducts")}
+            </p>
+          </div>
+
+          {isRecentTab && recentlyViewed.length > 0 && (
+            <button
+              type="button"
+              onClick={clearRecentlyViewed}
+              className="self-start rounded-full border border-border/70 bg-background/60 px-4 py-2 text-sm text-muted transition-colors hover:text-text"
+            >
+              {homeT("clearHistory")}
+            </button>
+          )}
+        </div>
+
+        {showRecentLoader ? (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <div
+                key={index}
+                className="h-95 animate-pulse rounded-[28px] border border-border/50 bg-surface/60"
+              />
+            ))}
+          </div>
+        ) : showRecentEmpty ? (
+          <div className="flex min-h-70 flex-col items-center justify-center rounded-[28px] border border-dashed border-border/70 bg-background/30 px-6 py-12 text-center">
+            <h3 className="text-xl font-semibold text-text">
+              {homeT("recentlyViewed")}
+            </h3>
+            <p className="mt-3 max-w-md text-sm text-muted">
+              {homeT("recentlyViewedEmpty")}
+            </p>
+            <button
+              type="button"
+              onClick={() => setActiveTab("featured")}
+              className="mt-6 rounded-full bg-button px-5 py-2.5 text-sm font-medium text-button-text transition-opacity hover:opacity-85"
+            >
+              {homeT("featuredProducts")}
+            </button>
+          </div>
+        ) : (
+          <div className="overflow-x-auto pb-2 md:overflow-visible">
+            <div className="flex gap-4 pb-4 md:grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 md:gap-6 md:pb-0">
+              {items.map((product) => (
+                <div
+                  key={`${activeTab}-${product.variant_id}`}
+                  className="w-72.5 min-w-72.5 shrink-0 md:w-auto md:min-w-0"
+                >
+                  <ProductCard
+                    data={product}
+                    otherInfo={
+                      isRecentTab
+                        ? undefined
+                        : {
+                            ...featuredOtherInfo,
+                            isFavorite: product?.isFavorite,
+                          }
+                    }
+                    contextLabel={
+                      isRecentTab
+                        ? homeT("recentlyViewed")
+                        : homeT("featuredProducts")
+                    }
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="flex justify-center pt-2">
+          <div className="inline-flex items-center rounded-full border border-border/70 bg-background/60 p-1 shadow-inner backdrop-blur">
+            {tabs.map((tab) => {
+              const isActive = tab.key === activeTab;
+
+              return (
+                <button
+                  key={tab.key}
+                  type="button"
+                  onClick={() => setActiveTab(tab.key)}
+                  className={`rounded-full px-5 py-2.5 text-sm font-medium transition-all duration-200 ${
+                    isActive
+                      ? "bg-button text-button-text shadow"
+                      : "text-muted hover:text-text"
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default HomeProductShowcaseClient;

--- a/src/widgets/home-product-showcase/ui/HomeProductShowcaseSection.jsx
+++ b/src/widgets/home-product-showcase/ui/HomeProductShowcaseSection.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { getFeaturedProducts } from "@/features/home";
+import HomeProductShowcaseClient from "./HomeProductShowcaseClient";
+
+const HomeProductShowcaseSection = async () => {
+  const response = await getFeaturedProducts(8);
+
+  return (
+    <HomeProductShowcaseClient
+      featuredProducts={response?.data || []}
+      featuredOtherInfo={response?.otherInfo || null}
+    />
+  );
+};
+
+export default HomeProductShowcaseSection;

--- a/src/widgets/home-product-showcase/ui/index.js
+++ b/src/widgets/home-product-showcase/ui/index.js
@@ -1,0 +1,1 @@
+export { default as HomeProductShowcaseSection } from "./HomeProductShowcaseSection";


### PR DESCRIPTION

## Summary

This PR implements a **Recently Viewed Products** feature that enhances product discovery by showing users products they've recently looked at.

## What was implemented

1. **useRecentlyViewed hook** ()
   - Manages recently viewed products in localStorage
   - Supports up to 10 products
   - Provides add, remove, and clear functionality
   - Persists across browser sessions

2. **RecentlyViewedProducts component** ()
   - Displays recently viewed products in a horizontal scrollable row
   - Shows on home page below Featured Products
   - Includes clear history button

3. **ProductViewTracker component** ()
   - Automatically tracks when users view a product detail page
   - Adds viewed products to recently viewed list

4. **Translations** - Added for all 3 languages (en, ru, fa):
   - recentlyViewed
   - clearHistory

## Bug fixes (pre-existing issues)

- Fixed NavLink import path in shared/index.js
- Fixed TypeScript errors in productMeta.ts
- Build configuration issue with vitest.config.ts

## How to test

1. Visit any product detail page
2. Go back to home page - you should see the product in "Recently Viewed"
3. Visit multiple products - they will appear in the recently viewed section
4. Click "Clear History" to reset the list

## Limitations

- Currently uses localStorage (not user account based)
- Products from guest users are not synced across devices
