### PR TITLE
Fix: Improve Google OAuth icon alt text for accessibility (#103)

### DIFF
--- a/src/features/auth/ui/OAuthForm/OAuthForm.jsx
+++ b/src/features/auth/ui/OAuthForm/OAuthForm.jsx
@@ -15,7 +15,7 @@ const OAuthForm = () => {
           src="/icons/google-color.png"
           width={18}
           height={18}
-          alt="Google"
+          alt="Sign in with Google"
         />
         <span>{t("continueWithGoogle")}</span>
       </button>


### PR DESCRIPTION
## ✅ What was done
- Changed the alt attribute on Google OAuth icon from "Google" to "Sign in with Google"
- This provides more descriptive text for screen readers

## 🧠 Why it matters
- Improves accessibility for visually impaired users
- Meets WCAG accessibility guidelines
- Screen readers can now properly describe the OAuth button action

## 🔗 Related Issues
- Closes #103

## ⚠️ Notes
- Build has pre-existing errors unrelated to this change (NavLink import issue in shared/index.js)
- Only modified the alt text, no other changes